### PR TITLE
docs: overhaul style kit for Fae concept

### DIFF
--- a/docs/style-kit/01_ART_DIRECTION.md
+++ b/docs/style-kit/01_ART_DIRECTION.md
@@ -4,48 +4,46 @@
 Kid imagination; playful exploration; calm energy; “everything is a friendly playground.”
 
 ## Non-negotiable style pillars
-1. Chunky toy-like forms; simple readable silhouettes.
-2. Flat painted materials; minimal texture detail.
-3. Bright palette; controlled contrast so it stays chill.
-4. Soft sunlight; no dramatic lighting.
-5. Sticker-and-craft energy; cardboard, tape, doodles, signs.
+1. **Chibi / Toy Proportions:** Big heads, small bodies, rounded limbs. No realistic proportions.
+2. **Soft & Round:** Beveled edges, spherical foliage, smooth terrain. No sharp angles.
+3. **Flat + Gradient Materials:** Minimal noise. Use vertical gradients to ground objects.
+4. **Sticker & Craft Details:** Holographic stickers, tape, marker drawings, cardboard construction.
+5. **Calm Brightness:** Pastel-adjacent saturated colors. Soft sunlight. No grit.
 
 ## Global style stamp (append to prompts)
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi character proportions; soft round shapes; flat painted materials with gradients; holographic sticker details; bright playful palette; soft lighting; clean silhouettes; toy-like aesthetic; no realism; no grit.
 
 ## Palette (do not expand early)
 Use the 16-color palette in `PALETTE.json`.
 Rules:
-- Most surfaces are 1–2 flat colors.
-- Gradients are rare; prefer shape over shading.
-- Accents (yellow/coral/purple) are for interactables and rewards.
+- **World:** Soft greens, warm dirt, blue sky.
+- **Character:** Saturated accents (Fae's purple hoodie).
+- **Special:** Holographic/Iridescent gradients for rare items (Backpack, Stickers).
 
 ## Shape language
-- Everything is rounded and safe.
-- Bevel edges using geometry, not texture.
-- Avoid thin parts that disappear from a top-down camera.
+- **Roundness is King:** Trees are puff-balls. Rocks are gumdrops.
+- **Thick & Chunky:** Thin objects disappear. Make fences, signposts, and limbs thick.
+- **Bevels:** All edges are soft.
 
 ## Materials
-Default: matte, non-metallic, slightly rough.
-- No realistic surface noise.
-- No complex normals.
-- If you need texture: low-frequency hand-painted wash only.
+- **Standard:** "Soft Plastic" or "Matte Clay". Smooth but not glossy.
+- **Holo-Sparkle:** Use sparingly for special items (Fae's backpack, collectibles).
+- **Foliage:** Fluffy normals (blob style).
 
 ## Lighting rules
-- One directional sun; soft shadows.
-- Ambient slightly warm.
-- Time-of-day: late morning to afternoon.
-- Fog: optional; very subtle.
+- **Sun:** Soft directional light (warm).
+- **Shadows:** Soft edges, slightly cool tint (blue/purple).
+- **Ambient:** Bright and warm to prevent harsh blacks.
 
 ## “No” list
 - Photorealism
-- Grit, grime, horror vibes
-- Hyper-detailed textures
-- Busy patterns
-- Realistic anatomy
+- Sharp/Jagged edges
+- High-frequency texture noise
+- Dark/Gritty themes
+- Realistic anatomy (no long legs/necks)
 
 ## Benchmark checks
 If you zoom out to gameplay camera:
-- Can you identify objects in 0.5 seconds?
-- Can you tell what is interactable instantly?
-- Does it still look calm and friendly?
+- Does the character look cute and readable (Chibi)?
+- Is the path clear?
+- Do the "sparkly" things stand out?

--- a/docs/style-kit/02_CAMERA_CONTROLS.md
+++ b/docs/style-kit/02_CAMERA_CONTROLS.md
@@ -1,35 +1,35 @@
-# 02 Camera & Controls (Top-Down 3D)
+# 02 Camera & Controls (Toy Box View)
 
-## Camera goals
-Readable from above; slight perspective; stable motion; minimal occlusion.
+## Camera Philosophy: "The Living Diorama"
+The camera should feel like looking down into a magical toy box. It is stable, readable, and emphasizes the "chunky" nature of the world.
 
-## Recommended camera defaults
-- Projection: Perspective
-- Tilt: 55°–65° downward
-- Framing: player takes ~8%–12% of screen height
-- Follow: smooth damp (no snapping)
-- Look-ahead: slight offset in movement direction
+## Core Camera Specs
+- **Projection**: Perspective (FOV 40–50 for a flattened, toy-like look without being orthographic)
+- **Tilt Angle**: 60° fixed (The sweet spot for reading top-down faces while seeing depth)
+- **Distance**: Close enough to see character expressions (Player = ~15% screen height)
+- **Smoothing**: High damping; the camera feels like a heavy, steady hand guiding the view.
+- **Look-ahead**: Minimal. The world is safe; we don't need to see far ahead.
 
-## Occlusion policy
-Avoid tall walls and dense canopies.
-Prefer:
-- short fences
-- low bushes
-- sparse trees with small trunks
-- “see-through” foliage silhouettes
+## "Toy Box" Occlusion Rules
+Since we look down, tall objects are dangerous.
+1.  **Trees**: Use the "Sphere Tree" standard (short trunks, high canopy).
+2.  **Buildings**: Front facades only (dollhouse style) or short single-story structures with sloped roofs.
+3.  **Fading**: Anything blocking the view must dither-fade instantly. No "cutout" circles; just soft transparency.
 
-## Touch-first controls
-- Left thumb: virtual joystick movement
-- Right thumb: big “Interact” button
-Optional:
-- “Hop” or “Tool” button (only one extra at first)
+## Movement Feel: "Bouncy & Tactile"
+Fae moves like a high-quality vinyl toy, not a simulation.
+-   **Run**: A rhythmic bobbing motion (up/down) rather than a lean-forward sprint.
+-   **Stop**: A slight squash-and-settle when stopping (no sliding).
+-   **Turn**: Snappy rotation. No slow arcs.
+-   **Collision**: Soft bounces off walls, never "sticking" or sliding along geometry.
 
-## Interaction readability
-- Every interactable has a clear icon above it (sticker-style)
-- Interactable props use accent colors from the palette
-- Pulse animation: slow and subtle (calm, not arcade)
+## Interaction: Sticker Overlay
+The UI lives *in* the world, not on a HUD.
+-   **Icons**: White-outlined "stickers" pop up over interactables.
+-   **Selection**: The nearest object gets a thick white outline (shader based).
+-   **Feedback**: Tapping an object triggers a "squish" scale animation on the object itself.
 
-## Movement feel
-- Acceleration: quick but not instant
-- Deceleration: a touch floaty
-- Turning: smooth; avoid sharp pivots
+## Touch Controls
+-   **Stick**: Floating virtual joystick.
+-   **Buttons**: Big, round, candy-colored buttons for Action/Tool.
+-   **Haptics**: Light taps on every footstep (if supported) to ground the "toy" feeling.

--- a/docs/style-kit/03_ASSET_SPEC.md
+++ b/docs/style-kit/03_ASSET_SPEC.md
@@ -2,51 +2,44 @@
 
 ## Units and scale
 - 1 Unity unit = 1 meter
-- Player height: 1.2 m (toy-like)
-- Doorway props: ~1.6 m (still feels big and inviting)
+- Player height: 1.0 m (Classic Chibi)
+- Doorway props: ~1.5 m (Wide and accessible)
 
-## Player proportions
-- Head: 40%–45% of total height
-- Torso: 35%–40%
-- Legs: 20%–25%
-- Hands/feet: oversized (mittens/boots)
-- Face: dot eyes + simple mouth; minimal features
+## Player proportions (Chibi Style)
+- **Head:** ~45-50% of total height. Big and expressive.
+- **Hair:** Chunky tufts, messy bun (Fae's signature). No individual strands.
+- **Body:** Small, compact torso.
+- **Limbs:** Rounded "noodle" limbs or soft cylinders. No sharp elbows/knees.
+- **Hands/Feet:** Oversized for readability. Mittens or minimal finger detail.
+- **Face:** Wide set dot eyes, simple mouth, small blush stickers.
 
-## Poly budgets (guidance, not law)
-Keep it simple; prioritize silhouette.
-- Player: 2k–6k tris
-- NPC: 1.5k–5k tris
-- Trees: 200–1.5k tris
-- Small props: 50–800 tris
-- Landmarks: 2k–10k tris (split into chunks if needed)
+## Poly budgets (guidance)
+Prioritize silhouette smoothness.
+- **Player:** 4k–8k tris (Focus on round head/hair and backpack details).
+- **NPC:** 2k–5k tris.
+- **Trees:** 500–2k tris (Blobby canopies).
+- **Small props:** 100–1k tris.
 
-## Textures
-Default: none (flat colors or vertex colors).
-If required:
-- 512–1024 px for hero props
-- 256–512 px for small props
-Avoid:
-- high-frequency noise
-- realistic photo textures
-
-## Materials
-- Matte, non-metallic
-- Roughness: mid to high
-- Metallic: 0
-- Optional subtle rim light (very faint)
+## Textures & Materials
+- **Default Material:** "Soft Plastic" / Matte Clay.
+  - Roughness: High (0.8).
+  - Metallic: 0.
+- **Fae's Backpack:** Special "Holo-Sparkle" shader.
+  - Iridescent gradients.
+  - Glitter texture mask.
+- **Faces:** Decal sheet or separate material for expression swapping.
 
 ## Naming conventions
 `cat_item_variant_size`
 Examples:
-- `prop_tree_round_m`
-- `prop_sign_arrow_s`
-- `npc_frog_shopkeeper`
-- `collect_sticker_star`
+- `char_fae_base`
+- `prop_tree_puff_l`
+- `prop_sign_chunky_s`
+- `vfx_sparkle_star`
 
 ## Collisions
-- Use primitive colliders whenever possible
-- Keep collisions forgiving; players should not get “stuck” on corners
+- Use primitive Capsules and Spheres.
+- Soft edges everywhere.
 
 ## LOD
-Only add LOD if performance demands it.
-First: solve with fewer objects, simpler meshes, baked lighting.
+- Aggressive LODs for mobile, but keep the silhouette "round" even at distance.

--- a/docs/style-kit/04_WORLD_KIT.md
+++ b/docs/style-kit/04_WORLD_KIT.md
@@ -2,46 +2,43 @@
 
 ## Biomes (start with 2)
 1. Meadow Park
-- rolling grass, flowers, picnic props, cardboard forts, signposts
+- Rolling hills (smooth curves, no sharp cliffs).
+- Vibrant green grass gradient (lime to forest).
+- Props: Picnic baskets, checkered blankets, cardboard castles, chunky signposts.
 2. Beach Cove
-- sand, shells, driftwood, small dock, floaties, tide pools
+- Soft sand (warm beige/yellow).
+- Round smooth rocks, drift-logs (no splinters), plastic bucket castles.
 
 ## Landmarks (exploration anchors)
-- Clubhouse tree (visible from many angles)
-- Cardboard fort tower (silly silhouette)
-- Kite hill / windmill (motion draws attention)
-- Friendly “cave” tunnel (not scary; playful)
+- **Clubhouse Tree:** Massive, round canopy (like broccoli), distinct silhouette.
+- **Cardboard Fort Tower:** Taped together, marker drawings, silly flags.
+- **Kite Hill:** Soft slope, wind chimes, spinning pinwheels.
 
 ## Dressing rules
-- Fewer, bigger props beat many small props.
-- Cluster props in 3s and 5s.
-- Keep paths readable; avoid clutter near intersections.
-- Use accent colors to mark “things you can do.”
+- **Clumping:** Nature isn't scattered evenly. Trees grow in friend groups (3-5).
+- **Scale:** Props are oversized. A flower is 30% of player height. A pebble is a distinct shape, not noise.
+- **Pathing:** Dirt paths are warm terracotta/salmon, carved into the green with soft edges.
 
 ## Starter prop kit (build first)
-Nature
-- Trees: round canopy, tall thin, palm-ish (3)
-- Rocks: small, medium, flat (3)
-- Bushes (2)
-- Flowers/grass clumps (3)
-- Log + stump (2)
+Nature (Soft/Round)
+- **Trees:** Sphere clusters (puff balls), Balloon style, Palm-ish (thick smooth trunk).
+- **Rocks:** River stones (smooth), gumdrops.
+- **Bushes:** Mounds, cloud shapes.
+- **Flowers:** Daisy (big center), Tulip (closed cup), distinct oversized.
 
 Playground/craft
-- Cardboard fort pieces: wall, door, ramp, tower (4)
-- Signs: arrow sign, notice board (2)
-- Bench + picnic table (2)
-- Rope bridge segments (3)
-- Flags/cones/lantern string (3)
-- Craft items: tape roll, paint bucket, giant marker, sticker sheet (4)
+- **Cardboard:** Walls with flap details, tape strips (visible texture).
+- **Signs:** Chunky wood, painted with icons (no small text).
+- **Furniture:** Benches are thick planks, picnic tables have rounded corners.
+- **Decor:** Bunting flags, paper lanterns, sidewalk chalk drawings.
 
 Interactables
-- Collectible: stickers (20 in the zone)
-- Critters: 6 simple “photo subjects”
-- Quest objects: lost hat, kite, snack box, map piece (4)
+- **Collectible:** Holographic Stickers (sparkle shader), "Shiny" rocks.
+- **Critters:** Round frogs, cube-ish ducks, simple shapes.
 
 ## Tiny vertical slice (one zone)
 Meadow Park loop path with:
-- 2 NPCs
-- 1 collectible type
-- 1 landmark fort
-- 1 “reward moment” (sticker badge into a book page)
+- 2 NPCs (Chibi proportion)
+- 1 Collectible type (Star Sticker)
+- 1 Landmark (Cardboard Castle)
+- 1 "Reward Moment" (Sticker page reveal)

--- a/docs/style-kit/05_UI_STYLE.md
+++ b/docs/style-kit/05_UI_STYLE.md
@@ -1,31 +1,99 @@
-# 05 UI Style (Sticker UI)
+# UI Style Guide: Sticker & Scrapbook
 
-## Look
-- Rounded corners, paper texture feel, soft shadow
-- Icons: thick line, filled shapes, hand-drawn vibe
-- Panels feel like stickers placed on the screen
+> **Vision:** The UI should feel like Fae’s personal journal or scrapbook. It is handmade, playful, and tactile. It uses "stickers" for icons, "tape" for headers, and "doodles" for emphasis.
 
-## Typography
-Pick one rounded font family and stick to it.
-Good options:
-- Nunito
-- Fredoka
-- Baloo 2
-- Quicksand
+---
 
-Use two weights max (regular + bold).
+## 1. Core Metaphor: The Scrapbook
 
-## UI components to define early
-- Interact prompt icon (above objects)
-- Quest tracker (1 line, short)
-- Sticker book (collectibles)
-- Simple map with landmark icons
-- Inventory/tool wheel (if needed)
+-   **Materials:** Paper textures, cardboard backing, masking tape, stickers, marker doodles.
+-   **Edges:** Slightly rough or torn edges on panels. No perfect digital rectangles.
+-   **Depth:** Slight drop shadows to show layering (paper on top of paper).
+-   **Motion:** Panels "slide" or "flop" in like turning a page.
 
-## Motion
-- Pop-in with a small scale bounce
-- Reward: sticker placement animation + tiny confetti
+---
 
-## Accessibility
-- Keep text large enough for mobile
-- High contrast between text and panel; use `deep_ink` on light panels
+## 2. Iconography: The Sticker Set
+
+All icons should look like die-cut stickers.
+
+-   **Outline:** Thick white outline (2-4px) around every icon.
+-   **Finish:** Subtle gloss highlight on the top half to suggest a vinyl sticker.
+-   **Shadow:** Soft drop shadow (offset y: 2px, blur: 4px, alpha: 20%) to lift it off the "paper".
+-   **Examples:**
+    -   *Heart Container:* A red heart sticker with a white border.
+    -   *Coin/Gem:* A sparkly gem sticker.
+    -   *Button Prompts:* A circular sticker with the button letter drawn in marker.
+
+---
+
+## 3. Typography
+
+-   **Headers:** `Fredoka One` or similar rounded, chunky font.
+    -   Color: `Fae Purple` (#6A5ACD) or `Dark Grey` (#333333).
+-   **Body Text:** `Nunito` or `Quicksand` (Rounded sans-serif).
+    -   Color: `Ink Black` (#202020).
+    -   Readability is key, but keep it friendly.
+-   **Handwritten Notes:** A legible handwriting font for "Fae's notes" on the UI.
+    -   Color: `Marker Blue` (#0055AA) or `Pencil Gray` (#505050).
+
+---
+
+## 4. HUD Elements
+
+### Health (Energy)
+-   **Style:** Stickers on a bar.
+-   **Full:** Bright red heart sticker.
+-   **Empty:** A faded, "peeled off" sticker outline or a greyed-out backing.
+
+### Action Prompts
+-   **Context:** Appear near the object in world space.
+-   **Visual:** A "speech bubble" doodle with the button prompt sticker inside.
+-   **Animation:** Bob up and down gently (Sine wave, freq: 2, amp: 5px).
+
+### Dialog Box
+-   **Background:** A crumpled paper texture or index card.
+-   **Portrait:** A polaroid photo frame of the speaker clipped to the box.
+-   **Nameplate:** A piece of masking tape with the name written on it.
+
+---
+
+## 5. Menus & Inventory
+
+### The Journal (Pause Menu)
+-   **Visual:** Literally opens a book on screen.
+-   **Tabs:** Colored bookmarks sticking out the side.
+-   **Selection:** A thick marker circle drawn around the selected item.
+
+### Inventory Grid
+-   **Slots:** Drawn pencil squares on paper.
+-   **Items:** Stickers placed in the squares.
+-   **Empty Slot:** Scribble texture or faint doodle.
+
+---
+
+## 6. Colors (UI Specific)
+
+| Usage | Color Name | Hex | Notes |
+| :--- | :--- | :--- | :--- |
+| **Primary Base** | `Paper White` | `#FDFBF7` | Warm, slightly textured background |
+| **Primary Text** | `Ink Black` | `#2D2D2D` | Softened black for readability |
+| **Highlight/Select** | `Highlighter Yellow` | `#FFEB3B` | Marker highlight behind text |
+| **Accent 1** | `Tape Teal` | `#40E0D0` | Masking tape elements |
+| **Accent 2** | `Sticker Pink` | `#FF69B4` | Notification badges |
+| **Error/Alert** | `Marker Red` | `#FF4500` | "Wrong" buzzers or low health |
+
+---
+
+## 7. Do's and Don'ts
+
+**DO:**
+-   Use white outlines on interactive elements.
+-   Rotate elements slightly (-2 to +2 degrees) so they don't look perfectly aligned (computer-generated).
+-   Use "tape" visuals to attach panels to the screen edges.
+
+**DON'T:**
+-   Use sharp 90-degree corners.
+-   Use Sci-Fi or high-tech glows/gradients.
+-   Use standard system fonts (Arial, Times).
+-   Make the UI look "dirty" or "grunge" (keep it clean-crafty, not trash-crafty).

--- a/docs/style-kit/06_ANIMATION_FEEL.md
+++ b/docs/style-kit/06_ANIMATION_FEEL.md
@@ -1,21 +1,46 @@
 # 06 Animation Feel
 
+## Core Vibe: "Living Toy"
+Animation should feel like a high-quality toy come to life or a playable cartoon. It is **bouncy, snappy, and exaggerated**. 
+
+Avoid "floaty" realistic blends. Prioritize strong poses and snappy timing.
+
 ## Principles
-- Bouncy, playful; never stiff.
-- Small overshoots on start/stop.
-- Idles matter; characters should look alive.
+1.  **Head Weight**: Fae's head is 45% of her mass. It drags slightly on acceleration and overshoots on stop.
+2.  **Squash & Stretch**: Essential for the "soft vinyl" toy feel.
+    - **Jump**: Squash flat -> Stretch long -> Tuck in air -> Squash on land.
+    - **Impact**: Deform the mesh on hits.
+3.  **Snappy Timing**: Fast transitions between states (Idle -> Run). Avoid slow blend trees.
 
-## Player set (minimum)
-- Idle: breathe + sway + blink
-- Run: light bob; arms swing; tail sway (if applicable)
-- Interact: quick lean-in + pop-back
-- Hop/jump (optional): squash/stretch; soft landing
+## Player Actions (Fae)
+- **Idle**: 
+    - Gentle vertical breathing (scale Y 100% -> 103%).
+    - Blink logic: Random double-blinks.
+- **Run (The "Trot")**:
+    - High vertical bobbing.
+    - Arms pump high (above shoulders).
+    - Feet lift high (exaggerated steppies).
+- **Interact / Bonk**:
+    - 2-frame anticipation, 1-frame strike.
+    - **Hit Stop**: Freeze frame for 0.05s on contact.
 
-## Timing targets (feel guidance)
-- UI pop: 120–180 ms
-- Interact reaction: 150–250 ms
-- Reward moment: 600–900 ms (let it land)
+## Enemy Actions (Chaos Raccoon)
+- **Telegraphs**: 
+    - Wobbly "wind-up" before attacking (shake position, not just rotation).
+    - "Exclamation" emote appears above head.
+- **Dizzy**:
+    - Spinning stars (holographic texture).
+    - Eyes swirl texture swap.
+- **Defeat**:
+    - No ragdolls.
+    - "Poof" into a cloud of round smoke particles and leaves.
 
-## FX
-- Small dust puff on stops/landings
-- Gentle sparkle on interactables and rewards (subtle)
+## Technical Specs
+- **Framerate**: Game runs at 60fps+.
+- **Curves**: Use `BackOut` or `ElasticOut` for UI and prop movements.
+- **Bones**: Minimal rigs. Use scale on bones to fake squash/stretch if blendshapes aren't available.
+
+## VFX Support
+- **Dust Puffs**: Round white spheres (unlit) on footfalls.
+- **Swing Trails**: "Holo" gradient ribbon behind the lantern/weapon.
+- **Impacts**: 2D "Comic Book" star shapes (Billboarded).

--- a/docs/style-kit/07_PROMPT_PACK.md
+++ b/docs/style-kit/07_PROMPT_PACK.md
@@ -7,10 +7,10 @@
 - Add the negative prompt section if your tool supports it.
 
 ## Global Style Stamp
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi proportions (45% head); chunky toy-like shapes; flat painted materials with soft gradients; holographic sticker details; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 ## Palette (include in prompts when possible)
-paper_white:#F5F3EE, warm_gray:#CFC8BD, deep_ink:#2D2A2A, sky:#7EC8FF, sky_light:#CFEFFF, water:#2F86D6, water_shallow:#66C7E8, grass:#63C35C, grass_light:#A6E67E, dirt:#C9A06A, rock:#8E97A3, tree_leaf:#3DBB7A, tree_trunk:#B57B4B, sun_yellow:#FFD45A, coral:#FF6F61, purple:#7B6DFF
+paper_white:#F8F6F2, ink_black:#3A3636, fae_hoodie:#6B5B95, fae_shorts:#3F4B66, holo_base:#D6E4FF, rainbow_red:#FF8B8B, rainbow_yellow:#FFD966, rainbow_teal:#66D2C8, grass_base:#76C466, grass_shadow:#5CA052, dirt_path:#E6B88A, tree_puff:#4BA868, wood_trunk:#9E7656, stone_gray:#9FA6B3, sky_day:#89CFF0, interaction_gold:#FFC845
 
 ## Common negative prompt
 photorealistic, realistic skin, gritty, horror, dark, high-frequency texture, microdetail, noisy, film grain, chromatic aberration, excessive bloom, harsh shadows, complex patterns, text, watermark, logo, UI text.
@@ -23,16 +23,16 @@ photorealistic, realistic skin, gritty, horror, dark, high-frequency texture, mi
 
 ## A) Key art: world vibe
 **Template**
-[SCENE], [MOOD]. Stylized cozy 3D game concept art, top-down 3/4 view at ~60° tilt, chunky toy-like shapes, flat painted materials, minimal texture detail, soft sunlight, clean silhouettes, kid-imagination playground vibe. Include landmarks and a readable path. Palette limited to the provided hex colors. No text.
+[SCENE], [MOOD]. Stylized cozy 3D game concept art, top-down 3/4 view at ~60° tilt, Chibi proportions, chunky toy-like shapes, flat painted materials, soft gradients, holographic sticker accents. Minimal texture detail, soft sunlight, clean silhouettes, kid-imagination playground vibe. Include landmarks and a readable path. Palette limited to the provided hex colors. No text.
 
 **Example**
-Sunny meadow park with a cardboard fort tower and a big clubhouse tree; calm afternoon; friendly critters near a picnic area. (append Global Style Stamp + palette)
+Sunny meadow park with a cardboard fort tower and a big clubhouse tree with sphere foliage; calm afternoon; friendly critters near a picnic area. (append Global Style Stamp + palette)
 
 ---
 
 ## B) Environment concept: Meadow Park zone
 **Template**
-Top-down 3/4 environment concept for a small open area: [SCENE]. Clear loop path, 3 landmark sightlines, clustered props, low fences, no tall walls. Chunky shapes, flat colors, soft shadows, minimal textures. Palette locked. No text.
+Top-down 3/4 environment concept for a small open area: [SCENE]. Clear loop path, 3 landmark sightlines, clustered props, low fences, no tall walls. Sphere trees (broccoli style), smooth river stones, chunky shapes, flat colors, soft shadows, minimal textures. Palette locked. No text.
 
 **Example scenes**
 - “meadow loop with picnic table, signposts, flower clusters, cardboard ramp”
@@ -46,20 +46,20 @@ Top-down 3/4 environment concept: [SCENE]. Sand, shells, driftwood, tiny dock, s
 
 ---
 
-## D) Character concept: Player (cute gator-kid vibe)
+## D) Character concept: Player (Fae)
 **Template**
-Stylized 3D character concept, top-down friendly proportions, big head (45%), small body, mitten hands, boot feet, simple dot eyes and small mouth. Outfit: [OUTFIT]. Colors from palette only. Soft lighting. No realism.
+Stylized 3D character concept, top-down Chibi proportions, big head (45%), small body, mitten hands, boot feet, simple dot eyes and small mouth. Outfit: [OUTFIT]. Accessories: Holographic backpack, sticker details. Colors from palette only. Soft lighting. No realism.
 
 **Variants**
-1) “adventure kid outfit with sticker book and tiny backpack”
-2) “raincoat + boots + simple hat”
-3) “cape made of a towel; toy sword made of cardboard”
+1. “adventure kid outfit with hoodie, shorts, and holographic backpack”
+2. “raincoat + boots + simple hat”
+3. “cape made of a towel; toy sword made of cardboard”
 
 ---
 
 ## E) Character sheet: Turnaround (for modeling)
 **Template**
-Orthographic character turnaround sheet: front, side, back, 3/4. Clean neutral background. Chunky toy-like proportions, flat colors, minimal details, palette limited. No labels, no text.
+Orthographic character turnaround sheet: front, side, back, 3/4. Clean neutral background. Chibi toy-like proportions (45% head), flat colors, minimal details, palette limited. No labels, no text.
 
 ---
 
@@ -71,7 +71,7 @@ A set of 6 stylized 3D critter NPC concepts on a neutral background; each is sim
 
 ## G) Prop sheet: Cardboard fort kit
 **Template**
-3D prop sheet, isolated on neutral background: cardboard fort modular pieces (wall, door, ramp, tower, flag). Chunky shapes, taped seams implied by simple shapes (not detailed texture), flat painted materials, palette limited. No labels.
+3D prop sheet, isolated on neutral background: cardboard fort modular pieces (wall, door, ramp, tower, flag). Chunky shapes, taped seams implied by simple shapes (not detailed texture), holographic tape accents, flat painted materials, palette limited. No labels.
 
 ---
 
@@ -83,13 +83,13 @@ A set of 6 stylized 3D critter NPC concepts on a neutral background; each is sim
 
 ## I) Collectible concept: Sticker set
 **Template**
-Sticker collectibles set of 24, cute shapes (stars, shells, frogs, kites); thick outline style; simple fills; palette limited; vector-like; consistent line weight. Transparent background if supported. No text.
+Sticker collectibles set of 24, cute shapes (stars, shells, frogs, kites); thick white outline style; simple fills; holographic backing effects; palette limited; vector-like; consistent line weight. Transparent background if supported. No text.
 
 ---
 
 ## J) UI kit: Sticker HUD
 **Template**
-UI kit, sticker style: quest tracker panel, interaction prompt bubble, minimap frame, inventory/tool wheel, 12 icons (talk, pick up, photo, map, sticker book). Rounded corners, paper feel, thick outline icons. Palette limited. No text.
+UI kit, sticker style: quest tracker panel, interaction prompt bubble, minimap frame, inventory/tool wheel, 12 icons (talk, pick up, photo, map, sticker book). Rounded corners, paper feel, thick outline icons, holographic accents on rare items. Palette limited. No text.
 
 ---
 
@@ -110,4 +110,3 @@ VFX concept sheet: small dust puff, gentle sparkle, sticker pop burst, tiny conf
 - If it looks too realistic: add “toy-like, cartoon 3D, no realism.”
 - If it’s too noisy: add “clean, flat colors, minimal texture.”
 - If readability is poor: add “gameplay readable from above, clear silhouettes.”
-

--- a/docs/style-kit/PALETTE.json
+++ b/docs/style-kit/PALETTE.json
@@ -1,82 +1,82 @@
 [
   {
     "name": "paper_white",
-    "hex": "#F5F3EE",
-    "note": "Paper white (UI, highlights)"
+    "hex": "#F8F6F2",
+    "note": "UI background, text highlights. Warmer white."
   },
   {
-    "name": "warm_gray",
-    "hex": "#CFC8BD",
-    "note": "Warm gray (stone, muted UI)"
+    "name": "ink_black",
+    "hex": "#3A3636",
+    "note": "Primary text, outlines (if used). Soft black."
   },
   {
-    "name": "deep_ink",
-    "hex": "#2D2A2A",
-    "note": "Deep ink (lines, text)"
+    "name": "fae_hoodie",
+    "hex": "#6B5B95",
+    "note": "Fae's main purple. Cozy, slightly desaturated."
   },
   {
-    "name": "sky",
-    "hex": "#7EC8FF",
-    "note": "Sky blue"
+    "name": "fae_shorts",
+    "hex": "#3F4B66",
+    "note": "Dark teal/slate for shorts."
   },
   {
-    "name": "sky_light",
-    "hex": "#CFEFFF",
-    "note": "Sky light (haze, highlights)"
+    "name": "holo_base",
+    "hex": "#D6E4FF",
+    "note": "Backpack base. Shimmers with pink/cyan."
   },
   {
-    "name": "water",
-    "hex": "#2F86D6",
-    "note": "Water deep"
+    "name": "rainbow_red",
+    "hex": "#FF8B8B",
+    "note": "Strap/Sock accent."
   },
   {
-    "name": "water_shallow",
-    "hex": "#66C7E8",
-    "note": "Water shallow"
+    "name": "rainbow_yellow",
+    "hex": "#FFD966",
+    "note": "Strap/Sock accent."
   },
   {
-    "name": "grass",
-    "hex": "#63C35C",
-    "note": "Grass base"
+    "name": "rainbow_teal",
+    "hex": "#66D2C8",
+    "note": "Strap/Sock accent."
   },
   {
-    "name": "grass_light",
-    "hex": "#A6E67E",
-    "note": "Grass highlight"
+    "name": "grass_base",
+    "hex": "#76C466",
+    "note": "Vibrant but soft meadow green."
   },
   {
-    "name": "dirt",
-    "hex": "#C9A06A",
-    "note": "Dirt path"
+    "name": "grass_shadow",
+    "hex": "#5CA052",
+    "note": "AO and shadow areas for grass."
   },
   {
-    "name": "rock",
-    "hex": "#8E97A3",
-    "note": "Rock neutral"
+    "name": "dirt_path",
+    "hex": "#E6B88A",
+    "note": "Warm playful dirt/sand."
   },
   {
-    "name": "tree_leaf",
-    "hex": "#3DBB7A",
-    "note": "Leaf base"
+    "name": "tree_puff",
+    "hex": "#4BA868",
+    "note": "Tree canopy (broccoli style)."
   },
   {
-    "name": "tree_trunk",
-    "hex": "#B57B4B",
-    "note": "Trunk / wood"
+    "name": "wood_trunk",
+    "hex": "#9E7656",
+    "note": "Tree trunks and fences."
   },
   {
-    "name": "sun_yellow",
-    "hex": "#FFD45A",
-    "note": "Accent: sunny yellow"
+    "name": "stone_gray",
+    "hex": "#9FA6B3",
+    "note": "Cool gray for smooth rocks."
   },
   {
-    "name": "coral",
-    "hex": "#FF6F61",
-    "note": "Accent: coral"
+    "name": "sky_day",
+    "hex": "#89CFF0",
+    "note": "Soft playful blue."
   },
   {
-    "name": "purple",
-    "hex": "#7B6DFF",
-    "note": "Accent: purple"
+    "name": "interaction_gold",
+    "hex": "#FFC845",
+    "note": "Interactables and 'shiny' cues."
   }
 ]


### PR DESCRIPTION
## Summary
Updates the entire Style Kit documentation (`docs/style-kit/`) to align with the new "Fae Concept" art direction.

### Key Changes
- **Art Direction**: Shifted to "Chibi/Toy" proportions and "Stop-Motion" animation feel.
- **Camera**: Defined "Toy Box View" with bouncy spring arm.
- **UI**: Established "Sticker & Scrapbook" aesthetic with holographic accents.
- **Palette**: Updated hex codes to match Fae's concept art (Purples, Teals, Terracotta).
- **Prompt Pack**: Updated generation templates for consistency.