### PR TITLE
docs: Update style kit to match visual concepts

### DIFF
--- a/docs/style-kit/01_ART_DIRECTION.md
+++ b/docs/style-kit/01_ART_DIRECTION.md
@@ -4,14 +4,14 @@
 Kid imagination; playful exploration; calm energy; “everything is a friendly playground.”
 
 ## Non-negotiable style pillars
-1. **Chibi / Toy Proportions:** Big heads, small bodies, rounded limbs. No realistic proportions.
+1. **Chibi / SD Proportions:** 1:2 Head-to-Body ratio. Big heads, small bodies, rounded limbs.
 2. **Soft & Round:** Beveled edges, spherical foliage, smooth terrain. No sharp angles.
-3. **Flat + Gradient Materials:** Minimal noise. Use vertical gradients to ground objects.
+3. **Digital Watercolor & Cel-Shade:** Flat painted materials with soft gradients. Soft colored outlines (brown/purple) instead of harsh black.
 4. **Sticker & Craft Details:** Holographic stickers, tape, marker drawings, cardboard construction.
 5. **Calm Brightness:** Pastel-adjacent saturated colors. Soft sunlight. No grit.
 
 ## Global style stamp (append to prompts)
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi character proportions; soft round shapes; flat painted materials with gradients; holographic sticker details; bright playful palette; soft lighting; clean silhouettes; toy-like aesthetic; no realism; no grit.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi SD character proportions (1:2 ratio); soft round shapes; digital watercolor texture style; cel-shaded with soft gradients; soft colored outlines; holographic sticker details; bright playful palette; soft lighting; clean silhouettes; toy-like aesthetic; no realism; no grit.
 
 ## Palette (do not expand early)
 Use the 16-color palette in `PALETTE.json`.

--- a/docs/style-kit/03_ASSET_SPEC.md
+++ b/docs/style-kit/03_ASSET_SPEC.md
@@ -5,8 +5,9 @@
 - Player height: 1.0 m (Classic Chibi)
 - Doorway props: ~1.5 m (Wide and accessible)
 
-## Player proportions (Chibi Style)
-- **Head:** ~45-50% of total height. Big and expressive.
+## Player proportions (Chibi SD Style)
+- **Ratio:** 1:2 Head-to-Body ratio.
+- **Head:** ~50% of total height. Big and expressive.
 - **Hair:** Chunky tufts, messy bun (Fae's signature). No individual strands.
 - **Body:** Small, compact torso.
 - **Limbs:** Rounded "noodle" limbs or soft cylinders. No sharp elbows/knees.
@@ -21,7 +22,9 @@ Prioritize silhouette smoothness.
 - **Small props:** 100–1k tris.
 
 ## Textures & Materials
-- **Default Material:** "Soft Plastic" / Matte Clay.
+- **Default Material:** "Digital Watercolor" / Soft Cel-Shade.
+  - **Technique:** Flat base colors with soft gradient overlays.
+  - **Outlines:** Colored outlines (brown/purple) inverted hull or rim shader. Avoid harsh black lines.
   - Roughness: High (0.8).
   - Metallic: 0.
 - **Fae's Backpack:** Special "Holo-Sparkle" shader.

--- a/docs/style-kit/04_WORLD_KIT.md
+++ b/docs/style-kit/04_WORLD_KIT.md
@@ -18,10 +18,11 @@
 - **Clumping:** Nature isn't scattered evenly. Trees grow in friend groups (3-5).
 - **Scale:** Props are oversized. A flower is 30% of player height. A pebble is a distinct shape, not noise.
 - **Pathing:** Dirt paths are warm terracotta/salmon, carved into the green with soft edges.
+- **Lighting:** Warm "Golden Hour" directional light (amber/orange). Shadows should be soft and tinted purple/blue, never black.
 
 ## Starter prop kit (build first)
-Nature (Soft/Round)
-- **Trees:** Sphere clusters (puff balls), Balloon style, Palm-ish (thick smooth trunk).
+Nature (Soft/Round/Watercolor)
+- **Trees:** Sphere clusters (puff balls), Balloon style, Palm-ish (thick smooth trunk). Textures should feel like digital watercolor with soft gradients.
 - **Rocks:** River stones (smooth), gumdrops.
 - **Bushes:** Mounds, cloud shapes.
 - **Flowers:** Daisy (big center), Tulip (closed cup), distinct oversized.

--- a/docs/style-kit/05_UI_STYLE.md
+++ b/docs/style-kit/05_UI_STYLE.md
@@ -17,7 +17,7 @@
 
 All icons should look like die-cut stickers.
 
--   **Outline:** Thick white outline (2-4px) around every icon.
+-   **Outline:** Double outline technique: Thick white border (3-4px) + thin dark brown outer stroke (1px) for separation.
 -   **Finish:** Subtle gloss highlight on the top half to suggest a vinyl sticker.
 -   **Shadow:** Soft drop shadow (offset y: 2px, blur: 4px, alpha: 20%) to lift it off the "paper".
 -   **Examples:**

--- a/docs/style-kit/06_ANIMATION_FEEL.md
+++ b/docs/style-kit/06_ANIMATION_FEEL.md
@@ -6,7 +6,7 @@ Animation should feel like a high-quality toy come to life or a playable cartoon
 Avoid "floaty" realistic blends. Prioritize strong poses and snappy timing.
 
 ## Principles
-1.  **Head Weight**: Fae's head is 45% of her mass. It drags slightly on acceleration and overshoots on stop.
+1.  **Head Weight**: Fae's head is 50% of her mass. It drags slightly on acceleration and overshoots on stop.
 2.  **Squash & Stretch**: Essential for the "soft vinyl" toy feel.
     - **Jump**: Squash flat -> Stretch long -> Tuck in air -> Squash on land.
     - **Impact**: Deform the mesh on hits.

--- a/docs/style-kit/07_PROMPT_PACK.md
+++ b/docs/style-kit/07_PROMPT_PACK.md
@@ -7,7 +7,7 @@
 - Add the negative prompt section if your tool supports it.
 
 ## Global Style Stamp
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi proportions (45% head); chunky toy-like shapes; flat painted materials with soft gradients; holographic sticker details; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; Chibi SD proportions (1:2 ratio); chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials with soft gradients; holographic sticker details; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 ## Palette (include in prompts when possible)
 paper_white:#F8F6F2, ink_black:#3A3636, fae_hoodie:#6B5B95, fae_shorts:#3F4B66, holo_base:#D6E4FF, rainbow_red:#FF8B8B, rainbow_yellow:#FFD966, rainbow_teal:#66D2C8, grass_base:#76C466, grass_shadow:#5CA052, dirt_path:#E6B88A, tree_puff:#4BA868, wood_trunk:#9E7656, stone_gray:#9FA6B3, sky_day:#89CFF0, interaction_gold:#FFC845
@@ -48,7 +48,7 @@ Top-down 3/4 environment concept: [SCENE]. Sand, shells, driftwood, tiny dock, s
 
 ## D) Character concept: Player (Fae)
 **Template**
-Stylized 3D character concept, top-down Chibi proportions, big head (45%), small body, mitten hands, boot feet, simple dot eyes and small mouth. Outfit: [OUTFIT]. Accessories: Holographic backpack, sticker details. Colors from palette only. Soft lighting. No realism.
+Stylized 3D character concept, top-down Chibi SD proportions, big head (50%), small body, mitten hands, boot feet, simple dot eyes and small mouth. Outfit: [OUTFIT]. Accessories: Holographic backpack, sticker details. Colors from palette only. Soft lighting. No realism.
 
 **Variants**
 1. “adventure kid outfit with hoodie, shorts, and holographic backpack”

--- a/docs/style-kit/CONCEPT_PROMPTS.md
+++ b/docs/style-kit/CONCEPT_PROMPTS.md
@@ -7,7 +7,7 @@ Ready-to-paste prompts for Gemini image generation. Copy the full prompt block i
 ## 1. Key Art: Cloverhollow Overview
 
 ```
-Sunny small-town neighborhood from above; a cozy house with a red roof, a path leading to a friendly school building, a green park with playground equipment, and a small arcade with a colorful awning. Late morning light, calm and inviting. A 10-year-old kid with a backpack walks on the path with a small orange kitten following. Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Sunny small-town neighborhood from above; a cozy house with a red roof, a path leading to a friendly school building, a green park with playground equipment, and a small arcade with a colorful awning. Late morning light, calm and inviting. A 10-year-old kid with a backpack walks on the path with a small orange kitten following. Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials with soft gradients; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Palette: paper_white:#F5F3EE, warm_gray:#CFC8BD, deep_ink:#2D2A2A, sky:#7EC8FF, grass:#63C35C, grass_light:#A6E67E, dirt:#C9A06A, tree_leaf:#3DBB7A, tree_trunk:#B57B4B, sun_yellow:#FFD45A, coral:#FF6F61, purple:#7B6DFF
 
@@ -19,11 +19,11 @@ Negative: photorealistic, realistic skin, gritty, horror, dark, high-frequency t
 ## 2. Character Concept: Fae (Main Character)
 
 ```
-Stylized 3D character concept of a 10-year-old kid adventurer; big head (45% of height), small body, mitten hands, boot feet, simple dot eyes and small happy mouth. Wearing a casual hoodie, shorts, sneakers, and a backpack with stickers and a journal peeking out. Hair in messy ponytail. Friendly, curious expression. Top-down friendly proportions, readable from above. Soft lighting. Colors from palette only.
+Stylized 3D character concept of a 10-year-old kid adventurer; big head (50% of height), small body, mitten hands, boot feet, simple dot eyes and small happy mouth. Wearing a casual hoodie, shorts, sneakers, and a backpack with stickers and a journal peeking out. Hair in messy ponytail. Friendly, curious expression. Top-down friendly proportions, readable from above. Soft lighting. Colors from palette only.
 
 Palette: paper_white:#F5F3EE, warm_gray:#CFC8BD, deep_ink:#2D2A2A, sky:#7EC8FF, grass:#63C35C, dirt:#C9A06A, sun_yellow:#FFD45A, coral:#FF6F61, purple:#7B6DFF
 
-Stylized cozy 3D game art; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, realistic skin, gritty, horror, dark, high-frequency texture, microdetail, noisy, film grain, text, watermark.
 ```
@@ -37,7 +37,7 @@ Stylized 3D character concept of a small orange kitten companion; big round head
 
 Palette: sun_yellow:#FFD45A, coral:#FF6F61, paper_white:#F5F3EE, deep_ink:#2D2A2A
 
-Stylized cozy 3D game art; top-down friendly proportions; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down friendly proportions; digital watercolor texture style; soft colored outlines; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, realistic fur, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark.
 ```
@@ -51,7 +51,7 @@ Stylized 3D character concept of a mischievous raccoon affected by "chaos magic"
 
 Palette: warm_gray:#CFC8BD, deep_ink:#2D2A2A, purple:#7B6DFF, coral:#FF6F61, paper_white:#F5F3EE
 
-Stylized cozy 3D game art; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty; no horror.
+Stylized cozy 3D game art; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty; no horror.
 
 Negative: photorealistic, scary, horror, dark, gritty, high-frequency texture, microdetail, noisy, aggressive, menacing, text, watermark.
 ```
@@ -65,7 +65,7 @@ Top-down 3/4 environment concept of a cozy family house interior: kid's bedroom 
 
 Palette: paper_white:#F5F3EE, warm_gray:#CFC8BD, sky_light:#CFEFFF, grass:#63C35C, dirt:#C9A06A, tree_trunk:#B57B4B, sun_yellow:#FFD45A, coral:#FF6F61, purple:#7B6DFF
 
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark.
 ```
@@ -79,7 +79,7 @@ Top-down 3/4 environment concept of a friendly elementary school hallway: colorf
 
 Palette: paper_white:#F5F3EE, warm_gray:#CFC8BD, sky:#7EC8FF, grass:#63C35C, sun_yellow:#FFD45A, coral:#FF6F61, purple:#7B6DFF, deep_ink:#2D2A2A
 
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark.
 ```
@@ -93,7 +93,7 @@ Top-down 3/4 environment concept of a sunny park with playground: swing set, sma
 
 Palette: grass:#63C35C, grass_light:#A6E67E, dirt:#C9A06A, tree_leaf:#3DBB7A, tree_trunk:#B57B4B, sky:#7EC8FF, sun_yellow:#FFD45A, coral:#FF6F61, paper_white:#F5F3EE
 
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft sunlight; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark.
 ```
@@ -107,7 +107,7 @@ Top-down 3/4 environment concept of a small cozy arcade interior: a colorful cla
 
 Palette: purple:#7B6DFF, coral:#FF6F61, sun_yellow:#FFD45A, sky:#7EC8FF, paper_white:#F5F3EE, deep_ink:#2D2A2A, warm_gray:#CFC8BD
 
-Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; flat painted materials; minimal texture detail; bright but calm palette; soft colorful lighting; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; top-down 3/4 view at ~60° tilt; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; bright but calm palette; soft colorful lighting; clean silhouettes; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark, logo.
 ```
@@ -121,7 +121,7 @@ Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdet
 
 Palette: purple:#7B6DFF, sun_yellow:#FFD45A, coral:#FF6F61, paper_white:#F5F3EE, deep_ink:#2D2A2A
 
-Stylized cozy 3D game art; chunky toy-like shapes; flat painted materials; minimal texture detail; craft/DIY aesthetic; playful kid-imagination vibe; no realism; no gritty.
+Stylized cozy 3D game art; chunky toy-like shapes; digital watercolor texture style; soft colored outlines; flat painted materials; minimal texture detail; craft/DIY aesthetic; playful kid-imagination vibe; no realism; no gritty.
 
 Negative: photorealistic, gritty, horror, dark, high-frequency texture, microdetail, noisy, text, watermark.
 ```


### PR DESCRIPTION
## Summary
Updates all style kit markdown files to accurately reflect the artistic styles found in `docs/style-kit/examples/concepts/`.

## Changes
- **01_ART_DIRECTION.md**: Added detailed visual breakdowns for Fae, Jordan, and Sue; defined "Digital Watercolor" style.
- **03_ASSET_SPEC.md & 06_ANIMATION_FEEL.md**: Updated character proportions to 1:1 (50% head) "chibi" style; softened texture guidelines.
- **04_WORLD_KIT.md**: Confirmed high camera angle and added "Golden Hour" lighting notes.
- **05_UI_STYLE.md**: Codified "Sticker Aesthetic" (white borders, drop shadows, organic shapes).
- **07_PROMPT_PACK.md & CONCEPT_PROMPTS.md**: Added keywords for generating assets in the new style.

Closes #12