### PR TITLE
feat: Add GameState, SaveSystem, SceneDirector, and RespawnSystem

### DIFF
--- a/UnityProject/Assets/_Project/Scripts/Core/FadeController.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/FadeController.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// Controls fade in/out transitions using a CanvasGroup.
+    /// Used by SceneDirector for smooth scene transitions.
+    /// </summary>
+    [RequireComponent(typeof(CanvasGroup))]
+    public class FadeController : MonoBehaviour
+    {
+        private CanvasGroup canvasGroup;
+
+        public bool IsFading { get; private set; }
+
+        private void Awake()
+        {
+            canvasGroup = GetComponent<CanvasGroup>();
+            SetAlpha(0f);
+        }
+
+        public Coroutine FadeOut(float duration)
+        {
+            return StartCoroutine(FadeCoroutine(0f, 1f, duration));
+        }
+
+        public Coroutine FadeIn(float duration)
+        {
+            return StartCoroutine(FadeCoroutine(1f, 0f, duration));
+        }
+
+        public void SetFadeImmediate(bool faded)
+        {
+            SetAlpha(faded ? 1f : 0f);
+        }
+
+        private IEnumerator FadeCoroutine(float from, float to, float duration)
+        {
+            IsFading = true;
+
+            if (duration <= 0f)
+            {
+                SetAlpha(to);
+                IsFading = false;
+                yield break;
+            }
+
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                SetAlpha(Mathf.Lerp(from, to, t));
+                yield return null;
+            }
+
+            SetAlpha(to);
+            IsFading = false;
+        }
+
+        private void SetAlpha(float alpha)
+        {
+            canvasGroup.alpha = alpha;
+            canvasGroup.blocksRaycasts = alpha > 0.5f;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/FadeController.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/FadeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4196ce76a943a476e8a7f7e74d9d76ba

--- a/UnityProject/Assets/_Project/Scripts/Core/GameConfig.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/GameConfig.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace CloverWilds.Core
+namespace WildsOfCloverhollow.Core
 {
     /// <summary>
     /// Game-wide configuration for scenes, anchors, and startup settings.

--- a/UnityProject/Assets/_Project/Scripts/Core/GameState.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/GameState.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// Plain C# class that holds all runtime game state.
+    /// This is NOT a ScriptableObject - it's runtime state managed by GameStateManager.
+    /// State is serialized to SaveData for persistence.
+    /// </summary>
+    public class GameState
+    {
+        // Story progression
+        public HashSet<string> storyFlags = new HashSet<string>();
+        public HashSet<string> discoveredNotes = new HashSet<string>();
+        public HashSet<string> revealedDoors = new HashSet<string>();
+
+        // Inventory
+        public int gems;
+        public int candyBars;
+
+        // Energy
+        public int currentEnergy = 100;
+        public int maxEnergy = 100;
+
+        // Current position (for save/load)
+        public string currentSceneName = "";
+        public Vector3 playerPosition;
+        public Quaternion playerRotation = Quaternion.identity;
+
+        // Tool unlocks stored as story flags:
+        // Tool.Lantern.Unlocked
+        // Tool.Lasso.Unlocked
+        // Tool.Flute.Unlocked
+
+        // Events
+        public event Action OnInventoryChanged;
+        public event Action<int, int> OnEnergyChanged; // current, max
+        public event Action OnStateLoaded;
+        public event Action<string> OnStoryFlagAdded;
+        public event Action<string> OnNoteDiscovered;
+        public event Action<string> OnDoorRevealed;
+        public event Action OnPlayerTired;
+
+        // Story Flags
+        public void AddStoryFlag(string flag)
+        {
+            if (storyFlags.Add(flag))
+            {
+                OnStoryFlagAdded?.Invoke(flag);
+            }
+        }
+
+        public bool HasStoryFlag(string flag)
+        {
+            return storyFlags.Contains(flag);
+        }
+
+        public void RemoveStoryFlag(string flag)
+        {
+            storyFlags.Remove(flag);
+        }
+
+        // Notes
+        public void DiscoverNote(string noteId)
+        {
+            if (discoveredNotes.Add(noteId))
+            {
+                OnNoteDiscovered?.Invoke(noteId);
+            }
+        }
+
+        public bool HasDiscoveredNote(string noteId)
+        {
+            return discoveredNotes.Contains(noteId);
+        }
+
+        // Doors
+        public void RevealDoor(string doorId)
+        {
+            if (revealedDoors.Add(doorId))
+            {
+                OnDoorRevealed?.Invoke(doorId);
+            }
+        }
+
+        public bool HasRevealedDoor(string doorId)
+        {
+            return revealedDoors.Contains(doorId);
+        }
+
+        // Inventory
+        public void AddGems(int amount)
+        {
+            gems = Mathf.Max(0, gems + amount);
+            OnInventoryChanged?.Invoke();
+        }
+
+        public void AddCandyBars(int amount)
+        {
+            candyBars = Mathf.Max(0, candyBars + amount);
+            OnInventoryChanged?.Invoke();
+        }
+
+        public bool TryConsumeCandyBar()
+        {
+            if (candyBars <= 0) return false;
+            candyBars--;
+            OnInventoryChanged?.Invoke();
+            return true;
+        }
+
+        // Energy
+        public void SetEnergy(int current, int max)
+        {
+            maxEnergy = Mathf.Max(1, max);
+            currentEnergy = Mathf.Clamp(current, 0, maxEnergy);
+            OnEnergyChanged?.Invoke(currentEnergy, maxEnergy);
+        }
+
+        public void TakeDamage(int amount)
+        {
+            int previousEnergy = currentEnergy;
+            currentEnergy = Mathf.Max(0, currentEnergy - amount);
+            OnEnergyChanged?.Invoke(currentEnergy, maxEnergy);
+
+            if (currentEnergy <= 0 && previousEnergy > 0)
+            {
+                OnPlayerTired?.Invoke();
+            }
+        }
+
+        public void RestoreEnergy(int amount)
+        {
+            currentEnergy = Mathf.Min(maxEnergy, currentEnergy + amount);
+            OnEnergyChanged?.Invoke(currentEnergy, maxEnergy);
+        }
+
+        public void RestoreToPercentage(float percentage)
+        {
+            currentEnergy = Mathf.RoundToInt(maxEnergy * Mathf.Clamp01(percentage));
+            OnEnergyChanged?.Invoke(currentEnergy, maxEnergy);
+        }
+
+        public bool IsFullEnergy => currentEnergy >= maxEnergy;
+        public bool IsTired => currentEnergy <= 0;
+
+        // Tool shortcuts
+        public bool IsLanternUnlocked => HasStoryFlag("Tool.Lantern.Unlocked");
+        public bool IsLassoUnlocked => HasStoryFlag("Tool.Lasso.Unlocked");
+        public bool IsFluteUnlocked => HasStoryFlag("Tool.Flute.Unlocked");
+
+        public void UnlockLantern() => AddStoryFlag("Tool.Lantern.Unlocked");
+        public void UnlockLasso() => AddStoryFlag("Tool.Lasso.Unlocked");
+        public void UnlockFlute() => AddStoryFlag("Tool.Flute.Unlocked");
+
+        // State management
+        public void NotifyStateLoaded()
+        {
+            OnStateLoaded?.Invoke();
+            OnInventoryChanged?.Invoke();
+            OnEnergyChanged?.Invoke(currentEnergy, maxEnergy);
+        }
+
+        /// <summary>
+        /// Resets state to defaults for a new game.
+        /// </summary>
+        public void Reset()
+        {
+            storyFlags.Clear();
+            discoveredNotes.Clear();
+            revealedDoors.Clear();
+            gems = 0;
+            candyBars = 0;
+            currentEnergy = 100;
+            maxEnergy = 100;
+            currentSceneName = "";
+            playerPosition = Vector3.zero;
+            playerRotation = Quaternion.identity;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/GameState.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/GameState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11a53ee3f2d2b4987966bfa189f7e26c

--- a/UnityProject/Assets/_Project/Scripts/Core/GameStateManager.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/GameStateManager.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// MonoBehaviour singleton that wraps GameState and provides access throughout the game.
+    /// Lives in the Bootstrap scene as part of PersistentRoot.
+    /// </summary>
+    public class GameStateManager : MonoBehaviour
+    {
+        private static GameStateManager instance;
+        private GameState gameState;
+
+        /// <summary>
+        /// Singleton instance of the GameStateManager.
+        /// </summary>
+        public static GameStateManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    Debug.LogWarning("[GameStateManager] Instance accessed before initialization!");
+                }
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// The current game state. Never null after initialization.
+        /// </summary>
+        public GameState State => gameState;
+
+        /// <summary>
+        /// Static shortcut to access game state directly.
+        /// </summary>
+        public static GameState Current => Instance?.State;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Debug.LogWarning("[GameStateManager] Duplicate instance destroyed.");
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            gameState = new GameState();
+            
+            Debug.Log("[GameStateManager] Initialized with fresh GameState.");
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Replaces the current state with a loaded state.
+        /// Used by SaveSystem after loading.
+        /// </summary>
+        public void SetState(GameState loadedState)
+        {
+            if (loadedState == null)
+            {
+                Debug.LogError("[GameStateManager] Cannot set null state!");
+                return;
+            }
+
+            gameState = loadedState;
+            gameState.NotifyStateLoaded();
+            
+            Debug.Log("[GameStateManager] State replaced from loaded data.");
+        }
+
+        /// <summary>
+        /// Resets the game state to defaults (for new game).
+        /// </summary>
+        public void ResetState()
+        {
+            gameState.Reset();
+            Debug.Log("[GameStateManager] State reset to defaults.");
+        }
+
+        /// <summary>
+        /// Updates player position in state. Called before saving.
+        /// </summary>
+        public void UpdatePlayerPosition(Vector3 position, Quaternion rotation)
+        {
+            gameState.playerPosition = position;
+            gameState.playerRotation = rotation;
+        }
+
+        /// <summary>
+        /// Updates current scene name in state.
+        /// </summary>
+        public void UpdateCurrentScene(string sceneName)
+        {
+            gameState.currentSceneName = sceneName;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/GameStateManager.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/GameStateManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 377a8d820f9f3479d941bb243b280912

--- a/UnityProject/Assets/_Project/Scripts/Core/RespawnSystem.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/RespawnSystem.cs
@@ -1,0 +1,137 @@
+using UnityEngine;
+using WildsOfCloverhollow.World;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// Handles player respawn when energy is depleted (tired state).
+    /// Respawn location depends on whether player is in an interior or exterior.
+    /// </summary>
+    public class RespawnSystem : MonoBehaviour
+    {
+        [Header("Configuration")]
+        [SerializeField] private GameConfig gameConfig;
+        [SerializeField] private float respawnEnergyPercentage = 0.5f;
+
+        private static RespawnSystem instance;
+        public static RespawnSystem Instance => instance;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        private void OnEnable()
+        {
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.OnPlayerTired += HandlePlayerTired;
+            }
+        }
+
+        private void OnDisable()
+        {
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.OnPlayerTired -= HandlePlayerTired;
+            }
+        }
+
+        private void Start()
+        {
+            // Re-subscribe in case GameStateManager wasn't ready in OnEnable
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.OnPlayerTired -= HandlePlayerTired;
+                state.OnPlayerTired += HandlePlayerTired;
+            }
+        }
+
+        private void HandlePlayerTired()
+        {
+            Debug.Log("[RespawnSystem] Player is tired! Initiating respawn...");
+            Respawn();
+        }
+
+        public void Respawn()
+        {
+            var sceneDirector = SceneDirector.Instance;
+            if (sceneDirector == null)
+            {
+                Debug.LogError("[RespawnSystem] SceneDirector not found!");
+                return;
+            }
+
+            // Restore energy to configured percentage
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.RestoreToPercentage(respawnEnergyPercentage);
+            }
+
+            // Determine respawn location
+            string respawnScene;
+            string respawnAnchorId;
+
+            if (sceneDirector.IsInterior)
+            {
+                // Interior: respawn at this scene's entrance
+                respawnScene = sceneDirector.CurrentScene;
+                respawnAnchorId = gameConfig != null 
+                    ? gameConfig.GetEntranceAnchorId(respawnScene) 
+                    : null;
+                
+                Debug.Log($"[RespawnSystem] Respawning at interior entrance: {respawnScene}");
+            }
+            else
+            {
+                // Exterior: respawn at home bed
+                respawnScene = gameConfig != null ? gameConfig.StartScene : "Cloverhollow";
+                respawnAnchorId = gameConfig != null ? gameConfig.HomeBedAnchorId : null;
+                
+                Debug.Log($"[RespawnSystem] Respawning at home bed: {respawnScene}");
+            }
+
+            // Trigger scene load (or reload)
+            if (respawnScene == sceneDirector.CurrentScene)
+            {
+                sceneDirector.ReloadCurrentScene(respawnAnchorId);
+            }
+            else
+            {
+                sceneDirector.LoadScene(respawnScene, respawnAnchorId);
+            }
+        }
+
+        /// <summary>
+        /// Teleports player to home bed without full respawn logic.
+        /// Used by debug tools.
+        /// </summary>
+        public void TeleportHome()
+        {
+            var sceneDirector = SceneDirector.Instance;
+            if (sceneDirector == null) return;
+
+            string homeScene = gameConfig != null ? gameConfig.StartScene : "Cloverhollow";
+            string homeAnchorId = gameConfig != null ? gameConfig.HomeBedAnchorId : null;
+
+            sceneDirector.LoadScene(homeScene, homeAnchorId);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/RespawnSystem.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/RespawnSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e335e58fbde2842e7b12a69174073380

--- a/UnityProject/Assets/_Project/Scripts/Core/SceneDirector.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/SceneDirector.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WildsOfCloverhollow.Player;
+using WildsOfCloverhollow.World;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// Manages scene transitions with fade effects and player spawning.
+    /// Handles additive scene loading while preserving the Bootstrap scene.
+    /// </summary>
+    public class SceneDirector : MonoBehaviour
+    {
+        [Header("Configuration")]
+        [SerializeField] private GameConfig gameConfig;
+        [SerializeField] private float fadeDuration = 0.5f;
+
+        [Header("References")]
+        [SerializeField] private FadeController fadeController;
+
+        private static SceneDirector instance;
+        public static SceneDirector Instance => instance;
+
+        private string currentContentScene;
+        private bool isTransitioning;
+
+        public string CurrentScene => currentContentScene;
+        public bool IsInterior => gameConfig != null && gameConfig.IsInterior(currentContentScene);
+        public bool IsTransitioning => isTransitioning;
+
+        public event Action<string> OnSceneLoadStarted;
+        public event Action<string> OnSceneLoadComplete;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        private void Start()
+        {
+            // Find currently loaded content scene (if any)
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                if (scene.isLoaded && scene.name != "Bootstrap")
+                {
+                    currentContentScene = scene.name;
+                    break;
+                }
+            }
+        }
+
+        public void LoadScene(string sceneName, string anchorId = null)
+        {
+            if (isTransitioning)
+            {
+                Debug.LogWarning("[SceneDirector] Already transitioning, ignoring request.");
+                return;
+            }
+
+            StartCoroutine(LoadSceneCoroutine(sceneName, anchorId));
+        }
+
+        public void LoadSceneAtPosition(string sceneName, Vector3 position, Quaternion rotation)
+        {
+            if (isTransitioning)
+            {
+                Debug.LogWarning("[SceneDirector] Already transitioning, ignoring request.");
+                return;
+            }
+
+            StartCoroutine(LoadSceneAtPositionCoroutine(sceneName, position, rotation));
+        }
+
+        public void ReloadCurrentScene(string anchorId = null)
+        {
+            if (string.IsNullOrEmpty(currentContentScene)) return;
+            LoadScene(currentContentScene, anchorId);
+        }
+
+        private IEnumerator LoadSceneCoroutine(string sceneName, string anchorId)
+        {
+            isTransitioning = true;
+            OnSceneLoadStarted?.Invoke(sceneName);
+
+            // Fade out
+            if (fadeController != null)
+            {
+                yield return fadeController.FadeOut(fadeDuration);
+            }
+
+            // Unload current content scene
+            yield return UnloadCurrentContentScene();
+
+            // Load new scene
+            yield return LoadContentScene(sceneName);
+
+            // Update state
+            currentContentScene = sceneName;
+            if (GameStateManager.Instance != null)
+            {
+                GameStateManager.Instance.UpdateCurrentScene(sceneName);
+            }
+
+            // Spawn player at anchor
+            yield return SpawnPlayerAtAnchor(anchorId);
+
+            // Fade in
+            if (fadeController != null)
+            {
+                yield return fadeController.FadeIn(fadeDuration);
+            }
+
+            isTransitioning = false;
+            OnSceneLoadComplete?.Invoke(sceneName);
+        }
+
+        private IEnumerator LoadSceneAtPositionCoroutine(string sceneName, Vector3 position, Quaternion rotation)
+        {
+            isTransitioning = true;
+            OnSceneLoadStarted?.Invoke(sceneName);
+
+            if (fadeController != null)
+            {
+                yield return fadeController.FadeOut(fadeDuration);
+            }
+
+            yield return UnloadCurrentContentScene();
+            yield return LoadContentScene(sceneName);
+
+            currentContentScene = sceneName;
+            if (GameStateManager.Instance != null)
+            {
+                GameStateManager.Instance.UpdateCurrentScene(sceneName);
+            }
+
+            // Spawn at specific position
+            var player = FindFirstObjectByType<PlayerController>();
+            if (player != null)
+            {
+                player.TeleportTo(position, rotation);
+            }
+
+            if (fadeController != null)
+            {
+                yield return fadeController.FadeIn(fadeDuration);
+            }
+
+            isTransitioning = false;
+            OnSceneLoadComplete?.Invoke(sceneName);
+        }
+
+        private IEnumerator UnloadCurrentContentScene()
+        {
+            if (string.IsNullOrEmpty(currentContentScene)) yield break;
+
+            var scene = SceneManager.GetSceneByName(currentContentScene);
+            if (scene.isLoaded)
+            {
+                var unloadOp = SceneManager.UnloadSceneAsync(scene);
+                while (unloadOp != null && !unloadOp.isDone)
+                {
+                    yield return null;
+                }
+            }
+        }
+
+        private IEnumerator LoadContentScene(string sceneName)
+        {
+            var scene = SceneManager.GetSceneByName(sceneName);
+            if (!scene.isLoaded)
+            {
+                var loadOp = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+                while (loadOp != null && !loadOp.isDone)
+                {
+                    yield return null;
+                }
+            }
+        }
+
+        private IEnumerator SpawnPlayerAtAnchor(string anchorId)
+        {
+            // Wait a frame for scene objects to initialize
+            yield return null;
+
+            var player = FindFirstObjectByType<PlayerController>();
+            if (player == null)
+            {
+                Debug.LogWarning("[SceneDirector] No PlayerController found in scene!");
+                yield break;
+            }
+
+            SpawnAnchor anchor = null;
+
+            // Try to find anchor by ID
+            if (!string.IsNullOrEmpty(anchorId))
+            {
+                anchor = FindAnchorById(anchorId);
+            }
+
+            // Fall back to scene entrance anchor
+            if (anchor == null && gameConfig != null)
+            {
+                var entranceId = gameConfig.GetEntranceAnchorId(currentContentScene);
+                if (!string.IsNullOrEmpty(entranceId))
+                {
+                    anchor = FindAnchorById(entranceId);
+                }
+            }
+
+            // Fall back to any anchor in scene
+            if (anchor == null)
+            {
+                anchor = FindFirstObjectByType<SpawnAnchor>();
+            }
+
+            if (anchor != null)
+            {
+                player.TeleportTo(anchor.SpawnPosition, anchor.SpawnRotation);
+                Debug.Log($"[SceneDirector] Player spawned at anchor: {anchor.AnchorId}");
+            }
+            else
+            {
+                Debug.LogWarning("[SceneDirector] No spawn anchor found, player position unchanged.");
+            }
+        }
+
+        private SpawnAnchor FindAnchorById(string anchorId)
+        {
+            var anchors = FindObjectsByType<SpawnAnchor>(FindObjectsSortMode.None);
+            foreach (var anchor in anchors)
+            {
+                if (anchor.AnchorId == anchorId)
+                {
+                    return anchor;
+                }
+            }
+            return null;
+        }
+
+        public SpawnAnchor FindHomeBedAnchor()
+        {
+            if (gameConfig == null) return null;
+            return FindAnchorById(gameConfig.HomeBedAnchorId);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/SceneDirector.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/SceneDirector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c6ac909ab6b3402683b6910ae6331bb

--- a/UnityProject/Assets/_Project/Scripts/DevTools/DebugOverlay.cs
+++ b/UnityProject/Assets/_Project/Scripts/DevTools/DebugOverlay.cs
@@ -1,13 +1,10 @@
 using UnityEngine;
 using UnityEngine.UI;
-using WildsOfCloverhollow.Bootstrap;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Save;
 
 namespace WildsOfCloverhollow.DevTools
 {
-    /// <summary>
-    /// Developer tools overlay with buttons for common debug actions.
-    /// Toggle visibility with F1 key or on-screen button.
-    /// </summary>
     public class DebugOverlay : MonoBehaviour
     {
         [Header("Button References")]
@@ -23,23 +20,53 @@ namespace WildsOfCloverhollow.DevTools
         [Header("Status Display")]
         [SerializeField] private Text statusText;
         
-        // Placeholder values for debug state (will be replaced by GameState later)
-        private int debugGems;
-        private int debugCandyBars;
-        private bool debugLanternUnlocked;
-        
         private void Awake()
         {
             SetupButtons();
         }
+
+        private void OnEnable()
+        {
+            SubscribeToStateEvents();
+            UpdateStatusDisplay();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromStateEvents();
+        }
         
         private void Update()
         {
-            // Toggle debug overlay with F1 key
             if (Input.GetKeyDown(KeyCode.F1))
             {
                 ToggleVisibility();
             }
+        }
+
+        private void SubscribeToStateEvents()
+        {
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.OnInventoryChanged += UpdateStatusDisplay;
+                state.OnStoryFlagAdded += OnStoryFlagChanged;
+            }
+        }
+
+        private void UnsubscribeFromStateEvents()
+        {
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.OnInventoryChanged -= UpdateStatusDisplay;
+                state.OnStoryFlagAdded -= OnStoryFlagChanged;
+            }
+        }
+
+        private void OnStoryFlagChanged(string flag)
+        {
+            UpdateStatusDisplay();
         }
         
         private void SetupButtons()
@@ -78,65 +105,118 @@ namespace WildsOfCloverhollow.DevTools
         
         private void UpdateStatusDisplay()
         {
-            if (statusText != null)
+            if (statusText == null) return;
+
+            var state = GameStateManager.Current;
+            if (state != null)
             {
-                statusText.text = $"Gems: {debugGems} | Candy: {debugCandyBars} | Lantern: {(debugLanternUnlocked ? "Yes" : "No")}";
+                statusText.text = $"Gems: {state.gems} | Candy: {state.candyBars} | Lantern: {(state.IsLanternUnlocked ? "Yes" : "No")} | Energy: {state.currentEnergy}/{state.maxEnergy}";
+            }
+            else
+            {
+                statusText.text = "GameState not initialized";
             }
         }
         
         private void LogAction(string action)
         {
-            UnityEngine.Debug.Log($"[DebugOverlay] {action}");
+            Debug.Log($"[DebugOverlay] {action}");
         }
-        
-        // Button handlers - these are stubs that will be connected to actual systems later
         
         private void OnSaveClicked()
         {
-            LogAction("Save requested (stub - SaveSystem not implemented)");
-            // TODO: Call SaveSystem.Save()
+            if (SaveSystem.Instance != null)
+            {
+                if (SaveSystem.Instance.Save())
+                {
+                    LogAction("Game saved successfully");
+                }
+                else
+                {
+                    LogAction("Save failed!");
+                }
+            }
+            else
+            {
+                LogAction("SaveSystem not found");
+            }
         }
         
         private void OnLoadClicked()
         {
-            LogAction("Load requested (stub - SaveSystem not implemented)");
-            // TODO: Call SaveSystem.Load()
+            if (SaveSystem.Instance != null)
+            {
+                if (SaveSystem.Instance.Load())
+                {
+                    LogAction("Game loaded successfully");
+                    UpdateStatusDisplay();
+                }
+                else
+                {
+                    LogAction("Load failed!");
+                }
+            }
+            else
+            {
+                LogAction("SaveSystem not found");
+            }
         }
         
         private void OnTeleportHomeClicked()
         {
-            LogAction("Teleport Home requested (stub - Player/SceneDirector not implemented)");
-            // TODO: Teleport player to home bed anchor
+            if (RespawnSystem.Instance != null)
+            {
+                RespawnSystem.Instance.TeleportHome();
+                LogAction("Teleporting home...");
+            }
+            else
+            {
+                LogAction("RespawnSystem not found");
+            }
         }
         
         private void OnGrantCandyClicked()
         {
-            debugCandyBars += 1;
-            LogAction($"Granted +1 Candy Bar. Total: {debugCandyBars}");
-            UpdateStatusDisplay();
-            // TODO: Update GameState.inventory.candyBars
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.AddCandyBars(1);
+                LogAction($"Granted +1 Candy Bar. Total: {state.candyBars}");
+            }
         }
         
         private void OnGrantGemsClicked()
         {
-            debugGems += 10;
-            LogAction($"Granted +10 Gems. Total: {debugGems}");
-            UpdateStatusDisplay();
-            // TODO: Update GameState.inventory.gems
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                state.AddGems(10);
+                LogAction($"Granted +10 Gems. Total: {state.gems}");
+            }
         }
         
         private void OnToggleLanternClicked()
         {
-            debugLanternUnlocked = !debugLanternUnlocked;
-            LogAction($"Lantern Unlocked: {debugLanternUnlocked}");
-            UpdateStatusDisplay();
-            // TODO: Toggle GameState.storyFlags.Contains("Tool.Lantern.Unlocked")
+            var state = GameStateManager.Current;
+            if (state != null)
+            {
+                if (state.IsLanternUnlocked)
+                {
+                    state.RemoveStoryFlag("Tool.Lantern.Unlocked");
+                    LogAction("Lantern locked");
+                }
+                else
+                {
+                    state.UnlockLantern();
+                    LogAction("Lantern unlocked");
+                }
+                UpdateStatusDisplay();
+            }
         }
         
         private void OnSpawnRaccoonClicked()
         {
-            LogAction("Spawn Raccoon requested (stub - Raccoon prefab not implemented)");
-            // TODO: Instantiate raccoon prefab near player
+            LogAction("Spawn Raccoon (stub - Raccoon prefab not implemented)");
         }
         
         private void OnCloseClicked()

--- a/UnityProject/Assets/_Project/Scripts/Save/SaveData.cs
+++ b/UnityProject/Assets/_Project/Scripts/Save/SaveData.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Save
+{
+    /// <summary>
+    /// Serializable data class for saving game state to disk.
+    /// Uses Lists instead of HashSets for JSON serialization compatibility.
+    /// </summary>
+    [Serializable]
+    public class SaveData
+    {
+        public const int CurrentVersion = 1;
+
+        public int version = CurrentVersion;
+        public string timestamp;
+
+        public string currentSceneName;
+        public float playerPositionX;
+        public float playerPositionY;
+        public float playerPositionZ;
+        public float playerRotationX;
+        public float playerRotationY;
+        public float playerRotationZ;
+        public float playerRotationW;
+
+        public List<string> storyFlags = new List<string>();
+        public List<string> discoveredNotes = new List<string>();
+        public List<string> revealedDoors = new List<string>();
+
+        public int gems;
+        public int candyBars;
+        public int currentEnergy;
+        public int maxEnergy;
+
+        public static SaveData FromGameState(Core.GameState state)
+        {
+            var data = new SaveData
+            {
+                version = CurrentVersion,
+                timestamp = DateTime.UtcNow.ToString("o"),
+                
+                currentSceneName = state.currentSceneName,
+                playerPositionX = state.playerPosition.x,
+                playerPositionY = state.playerPosition.y,
+                playerPositionZ = state.playerPosition.z,
+                playerRotationX = state.playerRotation.x,
+                playerRotationY = state.playerRotation.y,
+                playerRotationZ = state.playerRotation.z,
+                playerRotationW = state.playerRotation.w,
+                
+                gems = state.gems,
+                candyBars = state.candyBars,
+                currentEnergy = state.currentEnergy,
+                maxEnergy = state.maxEnergy
+            };
+
+            data.storyFlags.AddRange(state.storyFlags);
+            data.discoveredNotes.AddRange(state.discoveredNotes);
+            data.revealedDoors.AddRange(state.revealedDoors);
+
+            return data;
+        }
+
+        public Core.GameState ToGameState()
+        {
+            var state = new Core.GameState
+            {
+                currentSceneName = currentSceneName ?? "",
+                playerPosition = new Vector3(playerPositionX, playerPositionY, playerPositionZ),
+                playerRotation = new Quaternion(playerRotationX, playerRotationY, playerRotationZ, playerRotationW),
+                
+                gems = gems,
+                candyBars = candyBars,
+                currentEnergy = Mathf.Max(1, currentEnergy),
+                maxEnergy = Mathf.Max(1, maxEnergy)
+            };
+
+            if (storyFlags != null)
+            {
+                foreach (var flag in storyFlags)
+                {
+                    state.storyFlags.Add(flag);
+                }
+            }
+
+            if (discoveredNotes != null)
+            {
+                foreach (var noteId in discoveredNotes)
+                {
+                    state.discoveredNotes.Add(noteId);
+                }
+            }
+
+            if (revealedDoors != null)
+            {
+                foreach (var doorId in revealedDoors)
+                {
+                    state.revealedDoors.Add(doorId);
+                }
+            }
+
+            return state;
+        }
+
+        /// <summary>
+        /// Migrates data from older versions to the current version.
+        /// Returns true if migration was successful, false if data is incompatible.
+        /// </summary>
+        public bool TryMigrate()
+        {
+            if (version == CurrentVersion)
+            {
+                return true;
+            }
+
+            Debug.Log($"[SaveData] Migrating save from v{version} to v{CurrentVersion}");
+
+            // Add migration logic here as versions evolve
+            // Example:
+            // if (version < 2) { /* migrate v1 to v2 */ }
+            // if (version < 3) { /* migrate v2 to v3 */ }
+
+            version = CurrentVersion;
+            return true;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Save/SaveData.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Save/SaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e37d105688ac45ce8b5792e05a5af8a

--- a/UnityProject/Assets/_Project/Scripts/Save/SaveSystem.cs
+++ b/UnityProject/Assets/_Project/Scripts/Save/SaveSystem.cs
@@ -1,0 +1,246 @@
+using System;
+using System.IO;
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.Save
+{
+    /// <summary>
+    /// Handles saving and loading game state to disk.
+    /// Uses atomic writes to prevent corruption.
+    /// </summary>
+    public class SaveSystem : MonoBehaviour
+    {
+        private const string SaveFileName = "save.json";
+        private const string TempFileName = "save.tmp";
+        private const string BackupFileName = "save.bak";
+
+        private static SaveSystem instance;
+        public static SaveSystem Instance => instance;
+
+        public event Action OnSaveComplete;
+        public event Action OnLoadComplete;
+        public event Action<string> OnSaveError;
+        public event Action<string> OnLoadError;
+
+        private string SavePath => Path.Combine(Application.persistentDataPath, SaveFileName);
+        private string TempPath => Path.Combine(Application.persistentDataPath, TempFileName);
+        private string BackupPath => Path.Combine(Application.persistentDataPath, BackupFileName);
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+            Debug.Log($"[SaveSystem] Initialized. Save path: {SavePath}");
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        public bool Save()
+        {
+            var stateManager = GameStateManager.Instance;
+            if (stateManager == null)
+            {
+                Debug.LogError("[SaveSystem] GameStateManager not found!");
+                OnSaveError?.Invoke("GameStateManager not found");
+                return false;
+            }
+
+            var player = FindFirstObjectByType<Player.PlayerController>();
+            if (player != null)
+            {
+                stateManager.UpdatePlayerPosition(player.transform.position, player.transform.rotation);
+            }
+
+            var saveData = SaveData.FromGameState(stateManager.State);
+
+            try
+            {
+                string json = JsonUtility.ToJson(saveData, true);
+
+                // Atomic write: write to temp file first
+                File.WriteAllText(TempPath, json);
+
+                // Backup existing save
+                if (File.Exists(SavePath))
+                {
+                    if (File.Exists(BackupPath))
+                    {
+                        File.Delete(BackupPath);
+                    }
+                    File.Move(SavePath, BackupPath);
+                }
+
+                // Move temp to final location
+                File.Move(TempPath, SavePath);
+
+                Debug.Log($"[SaveSystem] Game saved successfully. Scene: {saveData.currentSceneName}");
+                OnSaveComplete?.Invoke();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SaveSystem] Save failed: {ex.Message}");
+                OnSaveError?.Invoke(ex.Message);
+
+                // Cleanup temp file if it exists
+                if (File.Exists(TempPath))
+                {
+                    try { File.Delete(TempPath); } catch { }
+                }
+
+                return false;
+            }
+        }
+
+        public bool Load()
+        {
+            if (!HasSaveFile())
+            {
+                Debug.Log("[SaveSystem] No save file found.");
+                OnLoadError?.Invoke("No save file found");
+                return false;
+            }
+
+            try
+            {
+                string json = File.ReadAllText(SavePath);
+                var saveData = JsonUtility.FromJson<SaveData>(json);
+
+                if (saveData == null)
+                {
+                    throw new Exception("Failed to parse save data");
+                }
+
+                if (!saveData.TryMigrate())
+                {
+                    throw new Exception($"Cannot migrate save from version {saveData.version}");
+                }
+
+                var newState = saveData.ToGameState();
+
+                var stateManager = GameStateManager.Instance;
+                if (stateManager == null)
+                {
+                    Debug.LogError("[SaveSystem] GameStateManager not found!");
+                    OnLoadError?.Invoke("GameStateManager not found");
+                    return false;
+                }
+
+                stateManager.SetState(newState);
+
+                Debug.Log($"[SaveSystem] Game loaded successfully. Scene: {saveData.currentSceneName}");
+                OnLoadComplete?.Invoke();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SaveSystem] Load failed: {ex.Message}");
+                OnLoadError?.Invoke(ex.Message);
+
+                // Try to load from backup
+                if (TryLoadBackup())
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        private bool TryLoadBackup()
+        {
+            if (!File.Exists(BackupPath))
+            {
+                Debug.Log("[SaveSystem] No backup file found.");
+                return false;
+            }
+
+            try
+            {
+                Debug.Log("[SaveSystem] Attempting to load from backup...");
+                string json = File.ReadAllText(BackupPath);
+                var saveData = JsonUtility.FromJson<SaveData>(json);
+
+                if (saveData == null || !saveData.TryMigrate())
+                {
+                    return false;
+                }
+
+                var newState = saveData.ToGameState();
+                var stateManager = GameStateManager.Instance;
+                if (stateManager != null)
+                {
+                    stateManager.SetState(newState);
+                    Debug.Log("[SaveSystem] Backup loaded successfully.");
+                    OnLoadComplete?.Invoke();
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SaveSystem] Backup load failed: {ex.Message}");
+            }
+
+            return false;
+        }
+
+        public bool HasSaveFile()
+        {
+            return File.Exists(SavePath);
+        }
+
+        public void DeleteSave()
+        {
+            try
+            {
+                if (File.Exists(SavePath))
+                {
+                    File.Delete(SavePath);
+                }
+                if (File.Exists(BackupPath))
+                {
+                    File.Delete(BackupPath);
+                }
+                if (File.Exists(TempPath))
+                {
+                    File.Delete(TempPath);
+                }
+                Debug.Log("[SaveSystem] Save files deleted.");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SaveSystem] Failed to delete save files: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Gets save metadata without loading the full state.
+        /// Useful for displaying save info in a menu.
+        /// </summary>
+        public SaveData GetSaveInfo()
+        {
+            if (!HasSaveFile()) return null;
+
+            try
+            {
+                string json = File.ReadAllText(SavePath);
+                return JsonUtility.FromJson<SaveData>(json);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Save/SaveSystem.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Save/SaveSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 320e97744da9c47c8aba4ece2fff742e


### PR DESCRIPTION
## Summary

Implements Issue #18: GameState + save/load + scene transitions + respawn for the Wilds of Cloverhollow Unity project.

Closes #18

## What's included

### Core Systems
- **GameState** (`Core/GameState.cs`): Plain C# class holding all runtime state
  - Story flags, discovered notes, revealed doors (HashSets)
  - Inventory (gems, candy bars)
  - Energy system with tired state events
  - Tool unlock shortcuts (Lantern, Lasso, Flute)

- **GameStateManager** (`Core/GameStateManager.cs`): MonoBehaviour singleton wrapper
  - Persistent access via `GameStateManager.Instance` and `GameStateManager.Current`
  - State replacement for load operations
  - Player position/scene tracking

### Save System
- **SaveData** (`Save/SaveData.cs`): Serializable class for JSON persistence
  - Version field for future migrations
  - Uses Lists for JSON compatibility (converted from HashSets)
  - `FromGameState()` and `ToGameState()` conversion methods

- **SaveSystem** (`Save/SaveSystem.cs`): File-based persistence
  - **Atomic writes**: temp file → backup existing → rename (prevents corruption)
  - Automatic backup of previous save
  - Fallback to backup on load failure
  - Events: `OnSaveComplete`, `OnLoadComplete`, `OnSaveError`, `OnLoadError`

### Scene Management
- **SceneDirector** (`Core/SceneDirector.cs`): Scene transitions
  - Additive scene loading (Bootstrap scene never unloads)
  - Fade in/out using FadeController
  - Player spawning at specified anchors
  - Interior/exterior tracking via GameConfig

- **FadeController** (`Core/FadeController.cs`): UI fade animation
  - Uses CanvasGroup for alpha animation
  - Blocks raycasts when faded

### Respawn System
- **RespawnSystem** (`Core/RespawnSystem.cs`): Handles tired state
  - Interior: respawn at that interior's entrance anchor
  - Exterior: respawn at home bed anchor
  - Restores energy to 50% of max
  - TeleportHome() for debug tools

### Integration
- Updated **DebugOverlay** to use SaveSystem and GameState
  - Save/Load buttons now functional
  - Teleport Home uses RespawnSystem
  - Grant Candy/Gems uses GameState
  - Toggle Lantern uses story flags

### Fixes
- Fixed namespace inconsistency: `CloverWilds.Core` → `WildsOfCloverhollow.Core`

## Architecture Notes

- GameState is a **plain C# class** (not ScriptableObject) because it's runtime state
- SaveSystem uses **atomic writes** (temp file → rename) to prevent corruption
- SceneDirector uses **additive loading** to keep Bootstrap scene persistent
- All systems use **events** for loose coupling (OnInventoryChanged, OnEnergyChanged, etc.)

## Testing

- Unity editmode tests pass (no compilation errors)
- All scripts compile successfully with Unity 6000.3.2f1

## Acceptance Criteria

- [x] GameState service holds all runtime state
- [x] SaveSystem with atomic writes and versioning
- [x] SceneDirector for scene transitions with fade
- [x] RespawnSystem for tired/death handling
- [x] DebugOverlay uses SaveSystem for Save/Load buttons