### PR TITLE
feat: Add Blacklight Lantern scanning, notes, hidden doors, and journal system

### DIFF
--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Doors/Door_ParkHedgeGate.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Doors/Door_ParkHedgeGate.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Door_ParkHedgeGate
+  m_EditorClassIdentifier: 
+  doorId: 326e80cb-d53c-42ed-a2da-405e4ce2ec56
+  displayName: Paw Hedge Gate
+  doorType: 0
+  targetScene: 
+  targetAnchorId: 
+  uvSymbolDescription: Three paw prints leading into a leaf outline
+  placementHint: "Cloverhollow Park area - hedge wall segment that visually looks like set dressing"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Doors/Door_SchoolStarCloset.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Doors/Door_SchoolStarCloset.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Door_SchoolStarCloset
+  m_EditorClassIdentifier: 
+  doorId: 97d2e256-8e98-45c2-83ae-417685f196b8
+  displayName: Star Closet
+  doorType: 0
+  targetScene: 
+  targetAnchorId: 
+  uvSymbolDescription: A star in the top-right corner of the door frame
+  placementHint: "SchoolInterior - a plain-looking closet door or locker panel in the hallway (close to NOTE 4)"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_01_GlowTime.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_01_GlowTime.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_01_GlowTime
+  m_EditorClassIdentifier: 
+  noteId: 05d763c1-0a81-46fc-9e99-4acb426c0b25
+  title: Glow Time
+  bodyText: If you can't see it, shine the light. Start with the road to school.
+  iconKey: icon_home
+  doodleSprite: {fileID: 0}
+  placementHint: "Fae's bedroom wall poster OR journal page on desk"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_02_FollowMe.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_02_FollowMe.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_02_FollowMe
+  m_EditorClassIdentifier: 
+  noteId: 3b59327c-3932-4c40-8ce5-15ea485a8898
+  title: Follow Me
+  bodyText: The real clue trail starts at school. Look for the star.
+  iconKey: icon_arrow
+  doodleSprite: {fileID: 0}
+  placementHint: "Sidewalk chalk near the main road out of the home yard"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_03_NotAllPosters.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_03_NotAllPosters.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_03_NotAllPosters
+  m_EditorClassIdentifier: 
+  noteId: f41b557b-e6a7-46f2-b225-e0b39b94f71f
+  title: Not All Posters
+  bodyText: Some notes are fake. The glowing one points the right way.
+  iconKey: icon_school
+  doodleSprite: {fileID: 0}
+  placementHint: "SchoolInterior - hallway bulletin board poster (near entrance)"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_04_StarCorner.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_04_StarCorner.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_04_StarCorner
+  m_EditorClassIdentifier: 
+  noteId: 00284283-34b5-4e17-bc1a-dbb97877d7ed
+  title: Star Corner
+  bodyText: The secret door has a star in the corner. Shine the frame.
+  iconKey: icon_star
+  doodleSprite: {fileID: 0}
+  placementHint: "SchoolInterior - outside the art room door frame OR on a nearby wall"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_05_SnackStash.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_05_SnackStash.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_05_SnackStash
+  m_EditorClassIdentifier: 
+  noteId: 7568df78-1f0d-4ba6-84d2-ac434c1a651b
+  title: Snack Stash
+  bodyText: Candy helps when things get wild. The park gets weird.
+  iconKey: icon_raccoon
+  doodleSprite: {fileID: 0}
+  placementHint: "SchoolInterior - inside the hidden room behind the closet door, on a small table next to the reward"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_06_TrashBandit.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_06_TrashBandit.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_06_TrashBandit
+  m_EditorClassIdentifier: 
+  noteId: 773a4316-f5a7-4566-9093-fec4194de64d
+  title: Trash Bandit
+  bodyText: Raccoons dash past you. Dodge when they swipe!
+  iconKey: icon_raccoon
+  doodleSprite: {fileID: 0}
+  placementHint: "Cloverhollow Park area - playground sign or trash can sticker near where the raccoon encounter triggers"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_07_PawGate.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_07_PawGate.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_07_PawGate
+  m_EditorClassIdentifier: 
+  noteId: 5b8be8fb-8042-4e74-afa8-7bdcd2f0f042
+  title: Paw Gate
+  bodyText: Paw prints mean a secret path. Shine the hedge.
+  iconKey: icon_paw
+  doodleSprite: {fileID: 0}
+  placementHint: "Cloverhollow Park area - hedge wall near the hidden gate"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_08_PrizeMachine.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Content/Notes/Note_08_PrizeMachine.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: Note_08_PrizeMachine
+  m_EditorClassIdentifier: 
+  noteId: 47523377-7034-48b4-b0dd-320f36cac78a
+  title: Prize Machine
+  bodyText: Win gems or candy. The center drop is the best!
+  iconKey: icon_arcade
+  doodleSprite: {fileID: 0}
+  placementHint: "ArcadeInterior - poster next to claw machine (visible only under blacklight)"

--- a/UnityProject/Assets/_Project/ScriptableObjects/Tuning/LanternTuning.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Tuning/LanternTuning.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0, type: 3}
+  m_Name: LanternTuning
+  m_EditorClassIdentifier: 
+  scanRange: 8
+  scanAngle: 45
+  revealDuration: 0.5
+  progressDecayRate: 0.5
+  scanFrequency: 15
+  maxRevealablesPerScan: 10

--- a/UnityProject/Assets/_Project/Scripts/Content/DoorDatabase.cs
+++ b/UnityProject/Assets/_Project/Scripts/Content/DoorDatabase.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Content
+{
+    /// <summary>
+    /// ScriptableObject database containing all hidden door definitions.
+    /// Used by HiddenDoorReveal and HiddenDoor to lookup door properties by ID.
+    /// </summary>
+    [CreateAssetMenu(fileName = "DoorDatabase", menuName = "Wilds/Content/Door Database")]
+    public class DoorDatabase : ScriptableObject
+    {
+        [SerializeField]
+        private List<DoorDefinition> doors = new List<DoorDefinition>();
+
+        // Cache for quick lookups
+        private Dictionary<string, DoorDefinition> doorCache;
+
+        /// <summary>
+        /// Gets all doors in the database.
+        /// </summary>
+        public IReadOnlyList<DoorDefinition> AllDoors => doors;
+
+        /// <summary>
+        /// Gets a door definition by its ID.
+        /// Returns null if not found.
+        /// </summary>
+        public DoorDefinition GetDoorById(string doorId)
+        {
+            if (string.IsNullOrEmpty(doorId))
+                return null;
+
+            EnsureCache();
+
+            if (doorCache.TryGetValue(doorId, out var door))
+                return door;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if a door with the given ID exists in the database.
+        /// </summary>
+        public bool HasDoor(string doorId)
+        {
+            return GetDoorById(doorId) != null;
+        }
+
+        private void EnsureCache()
+        {
+            if (doorCache != null)
+                return;
+
+            doorCache = new Dictionary<string, DoorDefinition>();
+            foreach (var door in doors)
+            {
+                if (door != null && !string.IsNullOrEmpty(door.doorId))
+                {
+                    if (!doorCache.ContainsKey(door.doorId))
+                    {
+                        doorCache[door.doorId] = door;
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[DoorDatabase] Duplicate door ID found: {door.doorId}");
+                    }
+                }
+            }
+        }
+
+        private void OnValidate()
+        {
+            // Invalidate cache when modified in editor
+            doorCache = null;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Content/DoorDefinition.cs
+++ b/UnityProject/Assets/_Project/Scripts/Content/DoorDefinition.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Content
+{
+    /// <summary>
+    /// Type of hidden door behavior when opened.
+    /// </summary>
+    public enum DoorType
+    {
+        /// <summary>
+        /// Door opens within the current scene (e.g., secret room behind a closet).
+        /// </summary>
+        ShortcutInScene,
+
+        /// <summary>
+        /// Door loads a different scene when opened.
+        /// </summary>
+        LoadSecretRoom
+    }
+
+    /// <summary>
+    /// ScriptableObject defining a hidden door's properties.
+    /// Door IDs must match the PersistentId on the scene object for persistence.
+    /// </summary>
+    [CreateAssetMenu(fileName = "Door_New", menuName = "Wilds/Content/Door Definition")]
+    public class DoorDefinition : ScriptableObject
+    {
+        [Header("Identification")]
+        [Tooltip("Unique ID for this door. Must match the PersistentId on the scene object.")]
+        public string doorId;
+
+        [Tooltip("Display name for the door (used in interaction prompt).")]
+        public string displayName = "Secret Door";
+
+        [Header("Behavior")]
+        [Tooltip("What happens when this door is opened.")]
+        public DoorType doorType = DoorType.ShortcutInScene;
+
+        [Tooltip("Target scene name (only used for LoadSecretRoom type).")]
+        public string targetScene;
+
+        [Tooltip("Target anchor ID in the target scene (only used for LoadSecretRoom type).")]
+        public string targetAnchorId;
+
+        [Header("Visual Hints")]
+        [Tooltip("Description of the UV symbol for documentation.")]
+        public string uvSymbolDescription;
+
+        [Tooltip("Optional scene hint for placement documentation.")]
+        public string placementHint;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Content/LanternTuning.cs
+++ b/UnityProject/Assets/_Project/Scripts/Content/LanternTuning.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Content
+{
+    [CreateAssetMenu(fileName = "LanternTuning", menuName = "Wilds/Tuning/Lantern Tuning")]
+    public class LanternTuning : ScriptableObject
+    {
+        [Header("Scanning")]
+        [Tooltip("Maximum distance for detecting revealables.")]
+        [Range(1f, 20f)]
+        public float scanRange = 8f;
+
+        [Tooltip("Scan cone half-angle in degrees. Objects outside this angle are ignored.")]
+        [Range(15f, 90f)]
+        public float scanAngle = 45f;
+
+        [Tooltip("Time in seconds to fully reveal an object.")]
+        [Range(0.1f, 2f)]
+        public float revealDuration = 0.5f;
+
+        [Tooltip("How fast progress decays when not being scanned (per second).")]
+        [Range(0f, 2f)]
+        public float progressDecayRate = 0.5f;
+
+        [Header("Performance")]
+        [Tooltip("Scans per second. Higher = more responsive but more CPU.")]
+        [Range(5f, 30f)]
+        public float scanFrequency = 15f;
+
+        [Tooltip("Maximum number of revealables to detect per scan.")]
+        [Range(1, 20)]
+        public int maxRevealablesPerScan = 10;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Content/NoteDatabase.cs
+++ b/UnityProject/Assets/_Project/Scripts/Content/NoteDatabase.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Content
+{
+    /// <summary>
+    /// ScriptableObject database containing all note definitions.
+    /// Used by NoteReveal and JournalPanel to lookup note content by ID.
+    /// </summary>
+    [CreateAssetMenu(fileName = "NoteDatabase", menuName = "Wilds/Content/Note Database")]
+    public class NoteDatabase : ScriptableObject
+    {
+        [SerializeField]
+        private List<NoteDefinition> notes = new List<NoteDefinition>();
+
+        // Cache for quick lookups
+        private Dictionary<string, NoteDefinition> noteCache;
+
+        /// <summary>
+        /// Gets all notes in the database.
+        /// </summary>
+        public IReadOnlyList<NoteDefinition> AllNotes => notes;
+
+        /// <summary>
+        /// Gets a note definition by its ID.
+        /// Returns null if not found.
+        /// </summary>
+        public NoteDefinition GetNoteById(string noteId)
+        {
+            if (string.IsNullOrEmpty(noteId))
+                return null;
+
+            EnsureCache();
+
+            if (noteCache.TryGetValue(noteId, out var note))
+                return note;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if a note with the given ID exists in the database.
+        /// </summary>
+        public bool HasNote(string noteId)
+        {
+            return GetNoteById(noteId) != null;
+        }
+
+        private void EnsureCache()
+        {
+            if (noteCache != null)
+                return;
+
+            noteCache = new Dictionary<string, NoteDefinition>();
+            foreach (var note in notes)
+            {
+                if (note != null && !string.IsNullOrEmpty(note.noteId))
+                {
+                    if (!noteCache.ContainsKey(note.noteId))
+                    {
+                        noteCache[note.noteId] = note;
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[NoteDatabase] Duplicate note ID found: {note.noteId}");
+                    }
+                }
+            }
+        }
+
+        private void OnValidate()
+        {
+            // Invalidate cache when modified in editor
+            noteCache = null;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Content/NoteDefinition.cs
+++ b/UnityProject/Assets/_Project/Scripts/Content/NoteDefinition.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Content
+{
+    /// <summary>
+    /// ScriptableObject defining a single blacklight note's content.
+    /// Note IDs must match the PersistentId on the scene object for persistence.
+    /// </summary>
+    [CreateAssetMenu(fileName = "Note_New", menuName = "Wilds/Content/Note Definition")]
+    public class NoteDefinition : ScriptableObject
+    {
+        [Header("Identification")]
+        [Tooltip("Unique ID for this note. Must match the PersistentId on the scene object.")]
+        public string noteId;
+
+        [Header("Content")]
+        [Tooltip("Title displayed in the popup and journal.")]
+        public string title;
+
+        [TextArea(2, 4)]
+        [Tooltip("Body text displayed in the popup and journal. Keep to 1-2 lines.")]
+        public string bodyText;
+
+        [Tooltip("Icon key for the journal list (e.g., icon_home, icon_school).")]
+        public string iconKey;
+
+        [Header("Visuals (Optional)")]
+        [Tooltip("Optional doodle sprite to display in the popup.")]
+        public Sprite doodleSprite;
+
+        [Tooltip("Optional scene hint for placement documentation.")]
+        public string placementHint;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Tools/BlacklightScanner.cs
+++ b/UnityProject/Assets/_Project/Scripts/Tools/BlacklightScanner.cs
@@ -1,0 +1,253 @@
+using UnityEngine;
+using WildsOfCloverhollow.Bootstrap;
+using WildsOfCloverhollow.Content;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.Tools
+{
+    public class BlacklightScanner : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private LanternTuning tuning;
+        [SerializeField] private Transform scanOrigin;
+        [SerializeField] private GameObject lanternVisualEffect;
+        
+        [Header("Layers")]
+        [SerializeField] private LayerMask revealableLayer;
+        
+        private bool isActive;
+        private float scanTimer;
+        private float scanInterval;
+        
+        private Collider[] scanResults;
+        private IBlacklightRevealable currentTarget;
+        private float currentProgress;
+        
+        public bool IsActive => isActive;
+        public IBlacklightRevealable CurrentTarget => currentTarget;
+        
+        public static BlacklightScanner Instance { get; private set; }
+        
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            
+            if (tuning != null)
+            {
+                scanInterval = 1f / tuning.scanFrequency;
+                scanResults = new Collider[tuning.maxRevealablesPerScan];
+            }
+            else
+            {
+                scanInterval = 1f / 15f;
+                scanResults = new Collider[10];
+            }
+            
+            if (scanOrigin == null)
+                scanOrigin = transform;
+                
+            SetLanternVisual(false);
+        }
+        
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+        
+        private void OnEnable()
+        {
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.OnLantern += HandleLanternInput;
+        }
+        
+        private void OnDisable()
+        {
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.OnLantern -= HandleLanternInput;
+        }
+        
+        private void Update()
+        {
+            if (!isActive)
+            {
+                DecayProgress();
+                return;
+            }
+            
+            scanTimer += Time.deltaTime;
+            if (scanTimer >= scanInterval)
+            {
+                scanTimer = 0f;
+                PerformScan();
+            }
+        }
+        
+        private void HandleLanternInput()
+        {
+            var gameState = GameStateManager.Instance?.State;
+            if (gameState == null || !gameState.IsLanternUnlocked)
+            {
+                Debug.Log("[BlacklightScanner] Lantern not unlocked yet.");
+                return;
+            }
+            
+            ToggleLantern();
+        }
+        
+        public void ToggleLantern()
+        {
+            isActive = !isActive;
+            SetLanternVisual(isActive);
+            
+            if (!isActive && currentTarget != null)
+            {
+                currentTarget.OnRevealInterrupted();
+                currentTarget = null;
+                currentProgress = 0f;
+            }
+            
+            Debug.Log($"[BlacklightScanner] Lantern {(isActive ? "ON" : "OFF")}");
+        }
+        
+        public void SetLanternActive(bool active)
+        {
+            if (isActive == active)
+                return;
+                
+            isActive = active;
+            SetLanternVisual(active);
+            
+            if (!active && currentTarget != null)
+            {
+                currentTarget.OnRevealInterrupted();
+                currentTarget = null;
+                currentProgress = 0f;
+            }
+        }
+        
+        private void SetLanternVisual(bool active)
+        {
+            if (lanternVisualEffect != null)
+                lanternVisualEffect.SetActive(active);
+        }
+        
+        private void PerformScan()
+        {
+            if (tuning == null)
+                return;
+                
+            Vector3 origin = scanOrigin.position;
+            Vector3 forward = scanOrigin.forward;
+            
+            int hitCount = Physics.OverlapSphereNonAlloc(
+                origin,
+                tuning.scanRange,
+                scanResults,
+                revealableLayer
+            );
+            
+            IBlacklightRevealable bestCandidate = null;
+            float bestScore = float.MaxValue;
+            
+            for (int i = 0; i < hitCount; i++)
+            {
+                var collider = scanResults[i];
+                if (collider == null)
+                    continue;
+                    
+                var revealable = collider.GetComponent<IBlacklightRevealable>();
+                if (revealable == null || revealable.IsRevealed)
+                    continue;
+                
+                Vector3 toTarget = collider.transform.position - origin;
+                float distance = toTarget.magnitude;
+                
+                if (distance < 0.01f)
+                    continue;
+                    
+                Vector3 directionToTarget = toTarget / distance;
+                float angle = Vector3.Angle(forward, directionToTarget);
+                
+                if (angle > tuning.scanAngle)
+                    continue;
+                
+                float score = distance + (angle * 0.1f);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    bestCandidate = revealable;
+                }
+            }
+            
+            if (bestCandidate != currentTarget)
+            {
+                if (currentTarget != null)
+                    currentTarget.OnRevealInterrupted();
+                    
+                currentTarget = bestCandidate;
+                currentProgress = 0f;
+                
+                if (currentTarget != null)
+                    currentTarget.OnRevealStart();
+            }
+            
+            if (currentTarget != null)
+            {
+                float progressIncrement = scanInterval / tuning.revealDuration;
+                currentProgress = Mathf.Min(1f, currentProgress + progressIncrement);
+                currentTarget.OnRevealProgress(currentProgress);
+                
+                if (currentProgress >= 1f)
+                {
+                    currentTarget.OnRevealComplete();
+                    currentTarget = null;
+                    currentProgress = 0f;
+                }
+            }
+        }
+        
+        private void DecayProgress()
+        {
+            if (currentTarget == null || tuning == null)
+                return;
+                
+            currentProgress -= tuning.progressDecayRate * Time.deltaTime;
+            
+            if (currentProgress <= 0f)
+            {
+                currentTarget.OnRevealInterrupted();
+                currentTarget = null;
+                currentProgress = 0f;
+            }
+            else
+            {
+                currentTarget.OnRevealProgress(currentProgress);
+            }
+        }
+        
+        private void OnDrawGizmosSelected()
+        {
+            if (tuning == null || scanOrigin == null)
+                return;
+                
+            Gizmos.color = isActive ? Color.cyan : Color.gray;
+            Gizmos.DrawWireSphere(scanOrigin.position, tuning.scanRange);
+            
+            Vector3 forward = scanOrigin.forward;
+            float halfAngle = tuning.scanAngle * Mathf.Deg2Rad;
+            
+            Vector3 right = Quaternion.AngleAxis(tuning.scanAngle, scanOrigin.up) * forward;
+            Vector3 left = Quaternion.AngleAxis(-tuning.scanAngle, scanOrigin.up) * forward;
+            
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawRay(scanOrigin.position, right * tuning.scanRange);
+            Gizmos.DrawRay(scanOrigin.position, left * tuning.scanRange);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Tools/HiddenDoorReveal.cs
+++ b/UnityProject/Assets/_Project/Scripts/Tools/HiddenDoorReveal.cs
@@ -1,0 +1,158 @@
+using System;
+using UnityEngine;
+using WildsOfCloverhollow.Content;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.World;
+
+namespace WildsOfCloverhollow.Tools
+{
+    [RequireComponent(typeof(PersistentId))]
+    public class HiddenDoorReveal : MonoBehaviour, IBlacklightRevealable
+    {
+        [Header("Door Reference")]
+        [SerializeField] private DoorDefinition doorDefinition;
+        [SerializeField] private DoorDatabase doorDatabase;
+        
+        [Header("Linked Door")]
+        [SerializeField] private HiddenDoor linkedDoor;
+        
+        [Header("Visuals")]
+        [SerializeField] private GameObject uvSymbolVisual;
+        [SerializeField] private GameObject revealProgressVFX;
+        
+        private PersistentId persistentId;
+        private float revealProgress;
+        private bool isRevealed;
+        private bool hasStartedReveal;
+        
+        public static event Action<DoorDefinition> OnDoorRevealed;
+        
+        public string GetRevealId()
+        {
+            if (doorDefinition != null)
+                return doorDefinition.doorId;
+                
+            if (persistentId != null)
+                return persistentId.Id;
+                
+            return null;
+        }
+        
+        public bool IsRevealed => isRevealed;
+        public float RevealProgress => revealProgress;
+        
+        private void Awake()
+        {
+            persistentId = GetComponent<PersistentId>();
+        }
+        
+        private void Start()
+        {
+            CheckIfAlreadyRevealed();
+            UpdateVisuals();
+            UpdateLinkedDoor();
+        }
+        
+        private void CheckIfAlreadyRevealed()
+        {
+            string doorId = GetRevealId();
+            if (string.IsNullOrEmpty(doorId))
+                return;
+                
+            var gameState = GameStateManager.Instance?.State;
+            if (gameState != null && gameState.HasRevealedDoor(doorId))
+            {
+                isRevealed = true;
+                revealProgress = 1f;
+            }
+        }
+        
+        private void UpdateVisuals()
+        {
+            if (uvSymbolVisual != null)
+                uvSymbolVisual.SetActive(isRevealed);
+                
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(false);
+        }
+        
+        private void UpdateLinkedDoor()
+        {
+            if (linkedDoor != null)
+            {
+                linkedDoor.SetRevealed(isRevealed);
+            }
+        }
+        
+        public void OnRevealStart()
+        {
+            if (isRevealed)
+                return;
+                
+            hasStartedReveal = true;
+            
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(true);
+        }
+        
+        public void OnRevealProgress(float progress)
+        {
+            if (isRevealed)
+                return;
+                
+            revealProgress = progress;
+        }
+        
+        public void OnRevealComplete()
+        {
+            if (isRevealed)
+                return;
+                
+            isRevealed = true;
+            revealProgress = 1f;
+            hasStartedReveal = false;
+            
+            string doorId = GetRevealId();
+            var gameState = GameStateManager.Instance?.State;
+            
+            if (gameState != null && !string.IsNullOrEmpty(doorId))
+            {
+                gameState.RevealDoor(doorId);
+            }
+            
+            UpdateVisuals();
+            UpdateLinkedDoor();
+            
+            DoorDefinition definition = GetDoorDefinition();
+            if (definition != null)
+            {
+                OnDoorRevealed?.Invoke(definition);
+            }
+            
+            Debug.Log($"[HiddenDoorReveal] Door revealed: {definition?.displayName ?? doorId}");
+        }
+        
+        public void OnRevealInterrupted()
+        {
+            if (isRevealed)
+                return;
+                
+            hasStartedReveal = false;
+            revealProgress = 0f;
+            
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(false);
+        }
+        
+        public DoorDefinition GetDoorDefinition()
+        {
+            if (doorDefinition != null)
+                return doorDefinition;
+                
+            if (doorDatabase != null && persistentId != null)
+                return doorDatabase.GetDoorById(persistentId.Id);
+                
+            return null;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Tools/IBlacklightRevealable.cs
+++ b/UnityProject/Assets/_Project/Scripts/Tools/IBlacklightRevealable.cs
@@ -1,0 +1,49 @@
+namespace WildsOfCloverhollow.Tools
+{
+    /// <summary>
+    /// Interface for objects that can be revealed by the blacklight lantern.
+    /// Implementations include notes (NoteReveal) and hidden doors (HiddenDoorReveal).
+    /// </summary>
+    public interface IBlacklightRevealable
+    {
+        /// <summary>
+        /// Returns the unique ID for this revealable object.
+        /// This ID is used for persistence (saving which objects have been revealed).
+        /// </summary>
+        string GetRevealId();
+
+        /// <summary>
+        /// Returns true if this object has already been revealed and persisted.
+        /// </summary>
+        bool IsRevealed { get; }
+
+        /// <summary>
+        /// Returns the current reveal progress from 0 (hidden) to 1 (fully revealed).
+        /// </summary>
+        float RevealProgress { get; }
+
+        /// <summary>
+        /// Called when the scanner first starts revealing this object.
+        /// Use this to start visual effects (glow, shimmer, etc.).
+        /// </summary>
+        void OnRevealStart();
+
+        /// <summary>
+        /// Called each scan tick while revealing.
+        /// </summary>
+        /// <param name="progress">Progress value from 0 to 1.</param>
+        void OnRevealProgress(float progress);
+
+        /// <summary>
+        /// Called when reveal is complete.
+        /// The implementation should mark itself as discovered in GameState.
+        /// </summary>
+        void OnRevealComplete();
+
+        /// <summary>
+        /// Called when scanning stops before completion (e.g., player moves away).
+        /// Use this to decay progress or hide partial reveal effects.
+        /// </summary>
+        void OnRevealInterrupted();
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Tools/NoteReveal.cs
+++ b/UnityProject/Assets/_Project/Scripts/Tools/NoteReveal.cs
@@ -1,0 +1,149 @@
+using System;
+using UnityEngine;
+using WildsOfCloverhollow.Content;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.World;
+
+namespace WildsOfCloverhollow.Tools
+{
+    [RequireComponent(typeof(PersistentId))]
+    public class NoteReveal : MonoBehaviour, IBlacklightRevealable
+    {
+        [Header("Note Reference")]
+        [SerializeField] private NoteDefinition noteDefinition;
+        [SerializeField] private NoteDatabase noteDatabase;
+        
+        [Header("Visuals")]
+        [SerializeField] private GameObject hiddenVisual;
+        [SerializeField] private GameObject revealedVisual;
+        [SerializeField] private GameObject revealProgressVFX;
+        
+        private PersistentId persistentId;
+        private float revealProgress;
+        private bool isRevealed;
+        private bool hasStartedReveal;
+        
+        public static event Action<NoteDefinition> OnNoteRevealed;
+        
+        public string GetRevealId()
+        {
+            if (noteDefinition != null)
+                return noteDefinition.noteId;
+                
+            if (persistentId != null)
+                return persistentId.Id;
+                
+            return null;
+        }
+        
+        public bool IsRevealed => isRevealed;
+        public float RevealProgress => revealProgress;
+        
+        private void Awake()
+        {
+            persistentId = GetComponent<PersistentId>();
+        }
+        
+        private void Start()
+        {
+            CheckIfAlreadyRevealed();
+            UpdateVisuals();
+        }
+        
+        private void CheckIfAlreadyRevealed()
+        {
+            string noteId = GetRevealId();
+            if (string.IsNullOrEmpty(noteId))
+                return;
+                
+            var gameState = GameStateManager.Instance?.State;
+            if (gameState != null && gameState.HasDiscoveredNote(noteId))
+            {
+                isRevealed = true;
+                revealProgress = 1f;
+            }
+        }
+        
+        private void UpdateVisuals()
+        {
+            if (hiddenVisual != null)
+                hiddenVisual.SetActive(!isRevealed);
+                
+            if (revealedVisual != null)
+                revealedVisual.SetActive(isRevealed);
+                
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(false);
+        }
+        
+        public void OnRevealStart()
+        {
+            if (isRevealed)
+                return;
+                
+            hasStartedReveal = true;
+            
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(true);
+        }
+        
+        public void OnRevealProgress(float progress)
+        {
+            if (isRevealed)
+                return;
+                
+            revealProgress = progress;
+        }
+        
+        public void OnRevealComplete()
+        {
+            if (isRevealed)
+                return;
+                
+            isRevealed = true;
+            revealProgress = 1f;
+            hasStartedReveal = false;
+            
+            string noteId = GetRevealId();
+            var gameState = GameStateManager.Instance?.State;
+            
+            if (gameState != null && !string.IsNullOrEmpty(noteId))
+            {
+                gameState.DiscoverNote(noteId);
+            }
+            
+            UpdateVisuals();
+            
+            NoteDefinition definition = GetNoteDefinition();
+            if (definition != null)
+            {
+                OnNoteRevealed?.Invoke(definition);
+            }
+            
+            Debug.Log($"[NoteReveal] Note revealed: {definition?.title ?? noteId}");
+        }
+        
+        public void OnRevealInterrupted()
+        {
+            if (isRevealed)
+                return;
+                
+            hasStartedReveal = false;
+            revealProgress = 0f;
+            
+            if (revealProgressVFX != null)
+                revealProgressVFX.SetActive(false);
+        }
+        
+        public NoteDefinition GetNoteDefinition()
+        {
+            if (noteDefinition != null)
+                return noteDefinition;
+                
+            if (noteDatabase != null && persistentId != null)
+                return noteDatabase.GetNoteById(persistentId.Id);
+                
+            return null;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/UI/JournalNoteEntry.cs
+++ b/UnityProject/Assets/_Project/Scripts/UI/JournalNoteEntry.cs
@@ -1,0 +1,49 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using WildsOfCloverhollow.Content;
+
+namespace WildsOfCloverhollow.UI
+{
+    public class JournalNoteEntry : MonoBehaviour
+    {
+        [Header("UI References")]
+        [SerializeField] private TextMeshProUGUI titleText;
+        [SerializeField] private Image iconImage;
+        [SerializeField] private GameObject newIndicator;
+        [SerializeField] private Button selectButton;
+        
+        private NoteDefinition noteDefinition;
+        private Action<NoteDefinition> onClickCallback;
+        
+        private void Awake()
+        {
+            if (selectButton != null)
+                selectButton.onClick.AddListener(OnClick);
+        }
+        
+        private void OnDestroy()
+        {
+            if (selectButton != null)
+                selectButton.onClick.RemoveListener(OnClick);
+        }
+        
+        public void Setup(NoteDefinition note, bool isNew, Action<NoteDefinition> onClick)
+        {
+            noteDefinition = note;
+            onClickCallback = onClick;
+            
+            if (titleText != null)
+                titleText.text = note.title;
+                
+            if (newIndicator != null)
+                newIndicator.SetActive(isNew);
+        }
+        
+        private void OnClick()
+        {
+            onClickCallback?.Invoke(noteDefinition);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/UI/JournalPanel.cs
+++ b/UnityProject/Assets/_Project/Scripts/UI/JournalPanel.cs
@@ -1,0 +1,236 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using WildsOfCloverhollow.Bootstrap;
+using WildsOfCloverhollow.Content;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.UI
+{
+    public class JournalPanel : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private NoteDatabase noteDatabase;
+        [SerializeField] private Transform noteListContainer;
+        [SerializeField] private GameObject noteEntryPrefab;
+        
+        [Header("Detail View")]
+        [SerializeField] private GameObject detailPanel;
+        [SerializeField] private TextMeshProUGUI detailTitleText;
+        [SerializeField] private TextMeshProUGUI detailBodyText;
+        [SerializeField] private Image detailDoodleImage;
+        [SerializeField] private Button closeDetailButton;
+        
+        [Header("Empty State")]
+        [SerializeField] private GameObject emptyStatePanel;
+        [SerializeField] private TextMeshProUGUI emptyStateText;
+        
+        [Header("Close Button")]
+        [SerializeField] private Button closeJournalButton;
+        
+        private HashSet<string> viewedNotes = new HashSet<string>();
+        private List<JournalNoteEntry> noteEntries = new List<JournalNoteEntry>();
+        
+        public static JournalPanel Instance { get; private set; }
+        
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            
+            if (closeJournalButton != null)
+                closeJournalButton.onClick.AddListener(CloseJournal);
+                
+            if (closeDetailButton != null)
+                closeDetailButton.onClick.AddListener(CloseDetail);
+        }
+        
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+                
+            if (closeJournalButton != null)
+                closeJournalButton.onClick.RemoveListener(CloseJournal);
+                
+            if (closeDetailButton != null)
+                closeDetailButton.onClick.RemoveListener(CloseDetail);
+        }
+        
+        private void OnEnable()
+        {
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.OnJournal += ToggleJournal;
+                
+            if (GameStateManager.Instance?.State != null)
+                GameStateManager.Instance.State.OnNoteDiscovered += OnNoteDiscovered;
+                
+            RefreshNoteList();
+            
+            if (detailPanel != null)
+                detailPanel.SetActive(false);
+        }
+        
+        private void OnDisable()
+        {
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.OnJournal -= ToggleJournal;
+                
+            if (GameStateManager.Instance?.State != null)
+                GameStateManager.Instance.State.OnNoteDiscovered -= OnNoteDiscovered;
+        }
+        
+        private void ToggleJournal()
+        {
+            if (gameObject.activeSelf)
+            {
+                CloseJournal();
+            }
+            else
+            {
+                OpenJournal();
+            }
+        }
+        
+        public void OpenJournal()
+        {
+            gameObject.SetActive(true);
+            RefreshNoteList();
+            
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.SetInputMode(InputRouter.InputMode.UI);
+        }
+        
+        public void CloseJournal()
+        {
+            CloseDetail();
+            gameObject.SetActive(false);
+            
+            if (InputRouter.Instance != null)
+                InputRouter.Instance.SetInputMode(InputRouter.InputMode.Gameplay);
+        }
+        
+        private void OnNoteDiscovered(string noteId)
+        {
+            if (gameObject.activeSelf)
+                RefreshNoteList();
+        }
+        
+        public void RefreshNoteList()
+        {
+            ClearNoteEntries();
+            
+            var gameState = GameStateManager.Instance?.State;
+            if (gameState == null || noteDatabase == null)
+            {
+                ShowEmptyState("No journal available.");
+                return;
+            }
+            
+            var discoveredNotes = gameState.discoveredNotes;
+            if (discoveredNotes.Count == 0)
+            {
+                ShowEmptyState("No notes discovered yet.\nUse the Blacklight Lantern to find hidden notes!");
+                return;
+            }
+            
+            HideEmptyState();
+            
+            foreach (var noteId in discoveredNotes)
+            {
+                var noteDefinition = noteDatabase.GetNoteById(noteId);
+                if (noteDefinition == null)
+                    continue;
+                    
+                CreateNoteEntry(noteDefinition);
+            }
+        }
+        
+        private void CreateNoteEntry(NoteDefinition note)
+        {
+            if (noteEntryPrefab == null || noteListContainer == null)
+                return;
+                
+            var entryGO = Instantiate(noteEntryPrefab, noteListContainer);
+            var entry = entryGO.GetComponent<JournalNoteEntry>();
+            
+            if (entry != null)
+            {
+                bool isNew = !viewedNotes.Contains(note.noteId);
+                entry.Setup(note, isNew, OnNoteEntryClicked);
+                noteEntries.Add(entry);
+            }
+        }
+        
+        private void OnNoteEntryClicked(NoteDefinition note)
+        {
+            viewedNotes.Add(note.noteId);
+            ShowDetail(note);
+            
+            RefreshNoteList();
+        }
+        
+        private void ShowDetail(NoteDefinition note)
+        {
+            if (detailPanel == null)
+                return;
+                
+            detailPanel.SetActive(true);
+            
+            if (detailTitleText != null)
+                detailTitleText.text = note.title;
+                
+            if (detailBodyText != null)
+                detailBodyText.text = note.bodyText;
+                
+            if (detailDoodleImage != null)
+            {
+                if (note.doodleSprite != null)
+                {
+                    detailDoodleImage.sprite = note.doodleSprite;
+                    detailDoodleImage.gameObject.SetActive(true);
+                }
+                else
+                {
+                    detailDoodleImage.gameObject.SetActive(false);
+                }
+            }
+        }
+        
+        private void CloseDetail()
+        {
+            if (detailPanel != null)
+                detailPanel.SetActive(false);
+        }
+        
+        private void ClearNoteEntries()
+        {
+            foreach (var entry in noteEntries)
+            {
+                if (entry != null)
+                    Destroy(entry.gameObject);
+            }
+            noteEntries.Clear();
+        }
+        
+        private void ShowEmptyState(string message)
+        {
+            if (emptyStatePanel != null)
+                emptyStatePanel.SetActive(true);
+                
+            if (emptyStateText != null)
+                emptyStateText.text = message;
+        }
+        
+        private void HideEmptyState()
+        {
+            if (emptyStatePanel != null)
+                emptyStatePanel.SetActive(false);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/UI/NotePopup.cs
+++ b/UnityProject/Assets/_Project/Scripts/UI/NotePopup.cs
@@ -1,0 +1,163 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using WildsOfCloverhollow.Content;
+
+namespace WildsOfCloverhollow.UI
+{
+    public class NotePopup : MonoBehaviour
+    {
+        [Header("UI References")]
+        [SerializeField] private TextMeshProUGUI titleText;
+        [SerializeField] private TextMeshProUGUI bodyText;
+        [SerializeField] private Image doodleImage;
+        [SerializeField] private Image iconImage;
+        [SerializeField] private Button closeButton;
+        [SerializeField] private CanvasGroup canvasGroup;
+        
+        [Header("Timing")]
+        [SerializeField] private float autoCloseDelay = 4f;
+        [SerializeField] private float fadeInDuration = 0.3f;
+        [SerializeField] private float fadeOutDuration = 0.2f;
+        
+        private float displayTimer;
+        private bool isClosing;
+        private bool isVisible;
+        
+        public static NotePopup Instance { get; private set; }
+        
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            
+            if (closeButton != null)
+                closeButton.onClick.AddListener(Close);
+                
+            Hide();
+        }
+        
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+                
+            if (closeButton != null)
+                closeButton.onClick.RemoveListener(Close);
+        }
+        
+        private void OnEnable()
+        {
+            WildsOfCloverhollow.Tools.NoteReveal.OnNoteRevealed += ShowNote;
+        }
+        
+        private void OnDisable()
+        {
+            WildsOfCloverhollow.Tools.NoteReveal.OnNoteRevealed -= ShowNote;
+        }
+        
+        private void Update()
+        {
+            if (!isVisible || isClosing)
+                return;
+                
+            displayTimer += Time.deltaTime;
+            if (displayTimer >= autoCloseDelay)
+            {
+                Close();
+            }
+        }
+        
+        public void ShowNote(NoteDefinition note)
+        {
+            if (note == null)
+                return;
+                
+            if (titleText != null)
+                titleText.text = note.title;
+                
+            if (bodyText != null)
+                bodyText.text = note.bodyText;
+                
+            if (doodleImage != null)
+            {
+                if (note.doodleSprite != null)
+                {
+                    doodleImage.sprite = note.doodleSprite;
+                    doodleImage.gameObject.SetActive(true);
+                }
+                else
+                {
+                    doodleImage.gameObject.SetActive(false);
+                }
+            }
+            
+            Show();
+        }
+        
+        public void Show()
+        {
+            gameObject.SetActive(true);
+            isVisible = true;
+            isClosing = false;
+            displayTimer = 0f;
+            
+            if (canvasGroup != null)
+            {
+                canvasGroup.alpha = 0f;
+                StartCoroutine(FadeIn());
+            }
+        }
+        
+        public void Close()
+        {
+            if (isClosing)
+                return;
+                
+            isClosing = true;
+            StartCoroutine(FadeOutAndHide());
+        }
+        
+        private void Hide()
+        {
+            isVisible = false;
+            isClosing = false;
+            gameObject.SetActive(false);
+        }
+        
+        private System.Collections.IEnumerator FadeIn()
+        {
+            float elapsed = 0f;
+            while (elapsed < fadeInDuration)
+            {
+                elapsed += Time.deltaTime;
+                if (canvasGroup != null)
+                    canvasGroup.alpha = Mathf.Clamp01(elapsed / fadeInDuration);
+                yield return null;
+            }
+            
+            if (canvasGroup != null)
+                canvasGroup.alpha = 1f;
+        }
+        
+        private System.Collections.IEnumerator FadeOutAndHide()
+        {
+            float elapsed = 0f;
+            float startAlpha = canvasGroup != null ? canvasGroup.alpha : 1f;
+            
+            while (elapsed < fadeOutDuration)
+            {
+                elapsed += Time.deltaTime;
+                if (canvasGroup != null)
+                    canvasGroup.alpha = Mathf.Lerp(startAlpha, 0f, elapsed / fadeOutDuration);
+                yield return null;
+            }
+            
+            Hide();
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/World/HiddenDoor.cs
+++ b/UnityProject/Assets/_Project/Scripts/World/HiddenDoor.cs
@@ -1,0 +1,145 @@
+using UnityEngine;
+using WildsOfCloverhollow.Content;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Interaction;
+
+namespace WildsOfCloverhollow.World
+{
+    public class HiddenDoor : MonoBehaviour, IInteractable
+    {
+        [Header("Door Reference")]
+        [SerializeField] private DoorDefinition doorDefinition;
+        
+        [Header("State")]
+        [SerializeField] private bool isRevealed;
+        [SerializeField] private bool isOpen;
+        
+        [Header("Visuals")]
+        [SerializeField] private GameObject closedVisual;
+        [SerializeField] private GameObject openVisual;
+        [SerializeField] private Collider doorCollider;
+        [SerializeField] private Collider blockingCollider;
+        
+        [Header("Scene Loading (for LoadSecretRoom type)")]
+        [SerializeField] private SceneDirector sceneDirector;
+        
+        public Transform Transform => transform;
+        
+        public bool IsRevealed => isRevealed;
+        public bool IsOpen => isOpen;
+        
+        private void Start()
+        {
+            CheckRevealedState();
+            UpdateVisuals();
+        }
+        
+        private void CheckRevealedState()
+        {
+            if (doorDefinition == null)
+                return;
+                
+            var gameState = GameStateManager.Instance?.State;
+            if (gameState != null && gameState.HasRevealedDoor(doorDefinition.doorId))
+            {
+                isRevealed = true;
+            }
+        }
+        
+        public void SetRevealed(bool revealed)
+        {
+            isRevealed = revealed;
+            UpdateVisuals();
+        }
+        
+        public string GetInteractionPrompt()
+        {
+            if (!isRevealed)
+                return null;
+                
+            if (isOpen)
+                return doorDefinition != null ? $"Close {doorDefinition.displayName}" : "Close Door";
+                
+            return doorDefinition != null ? $"Open {doorDefinition.displayName}" : "Open Secret Door";
+        }
+        
+        public bool CanInteract(GameObject interactor)
+        {
+            return isRevealed && !isOpen;
+        }
+        
+        public void Interact(GameObject interactor)
+        {
+            if (!isRevealed || isOpen)
+                return;
+                
+            OpenDoor();
+        }
+        
+        private void OpenDoor()
+        {
+            isOpen = true;
+            UpdateVisuals();
+            
+            if (doorDefinition != null)
+            {
+                var gameState = GameStateManager.Instance?.State;
+                if (gameState != null)
+                {
+                    string flagName = $"{doorDefinition.doorId}.Opened";
+                    gameState.AddStoryFlag(flagName);
+                }
+                
+                if (doorDefinition.doorType == DoorType.LoadSecretRoom)
+                {
+                    LoadSecretRoom();
+                }
+            }
+            
+            Debug.Log($"[HiddenDoor] Door opened: {doorDefinition?.displayName ?? "Unknown"}");
+        }
+        
+        private void LoadSecretRoom()
+        {
+            if (doorDefinition == null)
+                return;
+                
+            if (string.IsNullOrEmpty(doorDefinition.targetScene))
+            {
+                Debug.LogWarning("[HiddenDoor] LoadSecretRoom type but no target scene specified.");
+                return;
+            }
+            
+            var director = sceneDirector;
+            if (director == null)
+                director = SceneDirector.Instance;
+                
+            if (director != null)
+            {
+                director.LoadScene(doorDefinition.targetScene, doorDefinition.targetAnchorId);
+            }
+            else
+            {
+                Debug.LogError("[HiddenDoor] No SceneDirector available to load secret room.");
+            }
+        }
+        
+        private void UpdateVisuals()
+        {
+            bool shouldShowClosed = isRevealed && !isOpen;
+            bool shouldShowOpen = isRevealed && isOpen;
+            
+            if (closedVisual != null)
+                closedVisual.SetActive(shouldShowClosed);
+                
+            if (openVisual != null)
+                openVisual.SetActive(shouldShowOpen);
+            
+            if (doorCollider != null)
+                doorCollider.enabled = isRevealed;
+            
+            if (blockingCollider != null)
+                blockingCollider.enabled = !isOpen;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the complete Blacklight Lantern tool system for Issue #19:

- **IBlacklightRevealable interface** for objects that can be revealed by the lantern
- **BlacklightScanner** with throttled detection (15-20 Hz) using NonAlloc physics queries
- **NoteReveal** and **HiddenDoorReveal** components implementing the interface
- **NoteDatabase** and **DoorDatabase** ScriptableObjects for data-driven content
- **JournalPanel** UI for viewing discovered notes with new/viewed indicators
- **NotePopup** UI for displaying notes when discovered
- **HiddenDoor** IInteractable component for interacting with revealed doors

### Content Data

- 8 NoteDefinition assets with IDs matching poc-content-map.md
- 2 DoorDefinition assets (Star Closet and Paw Hedge Gate)
- LanternTuning ScriptableObject for tuning scan parameters

### Technical Notes

- Scanner uses `Physics.OverlapSphereNonAlloc` for zero-allocation scanning
- Scan frequency is configurable (default 15 Hz)
- Reveal progress accumulates over 0.5s (configurable)
- Events integrate with existing GameState for persistence

Closes #19