### PR TITLE
feat: Add energy system, candy bars, and pickup components

### DIFF
--- a/UnityProject/Assets/_Project/ScriptableObjects/Tuning/EnergyTuning.asset
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Tuning/EnergyTuning.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a3b9c8d1e2f4a5b6c7d8e9f0a1b2c3d, type: 3}
+  m_Name: EnergyTuning
+  m_EditorClassIdentifier: 
+  maxEnergy: 100
+  tiredThreshold: 0
+  candyRestoreAmount: 25
+  respawnEnergyPercent: 0.5

--- a/UnityProject/Assets/_Project/ScriptableObjects/Tuning/EnergyTuning.asset.meta
+++ b/UnityProject/Assets/_Project/ScriptableObjects/Tuning/EnergyTuning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b4c0d9e2f3a5b6c7d8e9f0a1b2c3d4e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/Core/EnergyTuning.cs
+++ b/UnityProject/Assets/_Project/Scripts/Core/EnergyTuning.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.Core
+{
+    /// <summary>
+    /// ScriptableObject containing energy system tuning values.
+    /// Allows designers to tweak energy and candy values without touching code.
+    /// </summary>
+    [CreateAssetMenu(fileName = "EnergyTuning", menuName = "CloverWilds/Tuning/EnergyTuning")]
+    public class EnergyTuning : ScriptableObject
+    {
+        [Header("Energy")]
+        [Tooltip("Maximum energy the player can have.")]
+        [SerializeField] private int maxEnergy = 100;
+
+        [Tooltip("Energy at or below which the player becomes tired.")]
+        [SerializeField] private int tiredThreshold = 0;
+
+        [Header("Candy Bars")]
+        [Tooltip("Amount of energy restored when consuming a candy bar.")]
+        [SerializeField] private int candyRestoreAmount = 25;
+
+        [Header("Respawn")]
+        [Tooltip("Percentage of max energy restored on respawn (0-1).")]
+        [SerializeField] private float respawnEnergyPercent = 0.5f;
+
+        // Public accessors
+        public int MaxEnergy => maxEnergy;
+        public int TiredThreshold => tiredThreshold;
+        public int CandyRestoreAmount => candyRestoreAmount;
+        public float RespawnEnergyPercent => respawnEnergyPercent;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Core/EnergyTuning.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Core/EnergyTuning.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a3b9c8d1e2f4a5b6c7d8e9f0a1b2c3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/Player/CandyConsumption.cs
+++ b/UnityProject/Assets/_Project/Scripts/Player/CandyConsumption.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.Player
+{
+    /// <summary>
+    /// Handles candy bar consumption to restore player energy.
+    /// Attach to the player GameObject or a persistent manager.
+    /// </summary>
+    public class CandyConsumption : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private EnergyTuning energyTuning;
+
+        [Header("Audio (Optional)")]
+        [SerializeField] private AudioSource audioSource;
+        [SerializeField] private AudioClip consumeSound;
+
+        [Header("VFX (Optional)")]
+        [SerializeField] private ParticleSystem consumeVFX;
+
+        private GameState gameState;
+
+        private void Start()
+        {
+            if (GameStateManager.Instance != null)
+            {
+                gameState = GameStateManager.Current;
+            }
+            else
+            {
+                Debug.LogWarning("[CandyConsumption] GameStateManager not found.");
+            }
+
+            if (energyTuning == null)
+            {
+                Debug.LogWarning("[CandyConsumption] EnergyTuning not assigned. Using default values.");
+            }
+        }
+
+        /// <summary>
+        /// Attempts to consume a candy bar to restore energy.
+        /// Returns true if successful, false if no candy or energy is full.
+        /// </summary>
+        public bool TryConsumeCandy()
+        {
+            if (gameState == null)
+            {
+                Debug.LogError("[CandyConsumption] No game state available!");
+                return false;
+            }
+
+            // Check if energy is already full
+            if (gameState.IsFullEnergy)
+            {
+                Debug.Log("[CandyConsumption] Cannot consume candy - energy is already full!");
+                return false;
+            }
+
+            // Check if we have candy bars
+            if (gameState.candyBars <= 0)
+            {
+                Debug.Log("[CandyConsumption] Cannot consume candy - no candy bars in inventory!");
+                return false;
+            }
+
+            // Consume the candy bar
+            if (!gameState.TryConsumeCandyBar())
+            {
+                return false;
+            }
+
+            // Restore energy
+            int restoreAmount = energyTuning != null ? energyTuning.CandyRestoreAmount : 25;
+            gameState.RestoreEnergy(restoreAmount);
+
+            // Play feedback
+            PlayConsumeFeedback();
+
+            Debug.Log($"[CandyConsumption] Consumed candy bar, restored {restoreAmount} energy. " +
+                      $"Current: {gameState.currentEnergy}/{gameState.maxEnergy}");
+
+            return true;
+        }
+
+        private void PlayConsumeFeedback()
+        {
+            // Play sound
+            if (audioSource != null && consumeSound != null)
+            {
+                audioSource.PlayOneShot(consumeSound);
+            }
+
+            // Play VFX
+            if (consumeVFX != null)
+            {
+                consumeVFX.Play();
+            }
+        }
+
+        /// <summary>
+        /// Check if candy can be consumed right now.
+        /// </summary>
+        public bool CanConsumeCandy()
+        {
+            if (gameState == null) return false;
+            return gameState.candyBars > 0 && !gameState.IsFullEnergy;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/Player/CandyConsumption.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/Player/CandyConsumption.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7f3a2b5c6d7e8f9a0b1c2d3e4f5a6b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/UI/EnergyHUD.cs
+++ b/UnityProject/Assets/_Project/Scripts/UI/EnergyHUD.cs
@@ -1,0 +1,205 @@
+using UnityEngine;
+using UnityEngine.UI;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.UI
+{
+    /// <summary>
+    /// Displays current energy in the HUD.
+    /// Supports both heart-based display (up to 5 hearts) and bar-based display.
+    /// Subscribe to GameState.OnEnergyChanged to update automatically.
+    /// </summary>
+    public class EnergyHUD : MonoBehaviour
+    {
+        public enum DisplayMode
+        {
+            Hearts,
+            Bar
+        }
+
+        [Header("Display Mode")]
+        [SerializeField] private DisplayMode displayMode = DisplayMode.Hearts;
+
+        [Header("Heart Display")]
+        [SerializeField] private Image[] heartImages;
+        [SerializeField] private Sprite heartFull;
+        [SerializeField] private Sprite heartEmpty;
+        [SerializeField] private Sprite heartHalf;
+
+        [Header("Bar Display")]
+        [SerializeField] private Image energyBarFill;
+        [SerializeField] private Image energyBarBackground;
+
+        [Header("Animation")]
+        [SerializeField] private float pulseScale = 1.1f;
+        [SerializeField] private float pulseDuration = 0.2f;
+
+        private int lastDisplayedEnergy = -1;
+        private GameState gameState;
+
+        private void Start()
+        {
+            // Subscribe to energy changes
+            if (GameStateManager.Instance != null)
+            {
+                gameState = GameStateManager.Current;
+                gameState.OnEnergyChanged += OnEnergyChanged;
+                
+                // Initial update
+                UpdateDisplay(gameState.currentEnergy, gameState.maxEnergy);
+            }
+            else
+            {
+                Debug.LogWarning("[EnergyHUD] GameStateManager not found. Energy display will not update.");
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (gameState != null)
+            {
+                gameState.OnEnergyChanged -= OnEnergyChanged;
+            }
+        }
+
+        private void OnEnergyChanged(int current, int max)
+        {
+            UpdateDisplay(current, max);
+        }
+
+        private void UpdateDisplay(int current, int max)
+        {
+            if (displayMode == DisplayMode.Hearts)
+            {
+                UpdateHeartDisplay(current, max);
+            }
+            else
+            {
+                UpdateBarDisplay(current, max);
+            }
+
+            // Pulse effect when taking damage
+            if (lastDisplayedEnergy > current && lastDisplayedEnergy >= 0)
+            {
+                TriggerDamagePulse();
+            }
+
+            lastDisplayedEnergy = current;
+        }
+
+        private void UpdateHeartDisplay(int current, int max)
+        {
+            if (heartImages == null || heartImages.Length == 0)
+            {
+                return;
+            }
+
+            // Calculate hearts - each heart represents 20% of max energy (for 5 hearts)
+            int maxHearts = heartImages.Length;
+            float energyPerHeart = (float)max / maxHearts;
+
+            for (int i = 0; i < maxHearts; i++)
+            {
+                if (heartImages[i] == null) continue;
+
+                float heartThreshold = energyPerHeart * i;
+                float heartFillPoint = energyPerHeart * (i + 1);
+                float halfPoint = heartThreshold + (energyPerHeart * 0.5f);
+
+                if (current >= heartFillPoint)
+                {
+                    // Full heart
+                    SetHeartSprite(heartImages[i], heartFull);
+                }
+                else if (current > halfPoint && heartHalf != null)
+                {
+                    // More than half, show full (or half if available)
+                    SetHeartSprite(heartImages[i], heartFull);
+                }
+                else if (current > heartThreshold && heartHalf != null)
+                {
+                    // Half heart
+                    SetHeartSprite(heartImages[i], heartHalf);
+                }
+                else if (current > heartThreshold)
+                {
+                    // Some energy but no half sprite, show full
+                    SetHeartSprite(heartImages[i], heartFull);
+                }
+                else
+                {
+                    // Empty heart
+                    SetHeartSprite(heartImages[i], heartEmpty);
+                }
+            }
+        }
+
+        private void SetHeartSprite(Image heart, Sprite sprite)
+        {
+            if (heart != null && sprite != null)
+            {
+                heart.sprite = sprite;
+            }
+        }
+
+        private void UpdateBarDisplay(int current, int max)
+        {
+            if (energyBarFill == null) return;
+
+            float fillAmount = max > 0 ? (float)current / max : 0f;
+            energyBarFill.fillAmount = fillAmount;
+
+            // Color gradient from green to red based on fill
+            Color healthColor = Color.Lerp(Color.red, Color.green, fillAmount);
+            energyBarFill.color = healthColor;
+        }
+
+        private void TriggerDamagePulse()
+        {
+            // Simple scale pulse - can be enhanced with DOTween later
+            StopAllCoroutines();
+            StartCoroutine(PulseCoroutine());
+        }
+
+        private System.Collections.IEnumerator PulseCoroutine()
+        {
+            Vector3 originalScale = transform.localScale;
+            Vector3 targetScale = originalScale * pulseScale;
+
+            float elapsed = 0f;
+            float halfDuration = pulseDuration * 0.5f;
+
+            // Scale up
+            while (elapsed < halfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / halfDuration;
+                transform.localScale = Vector3.Lerp(originalScale, targetScale, t);
+                yield return null;
+            }
+
+            // Scale down
+            elapsed = 0f;
+            while (elapsed < halfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / halfDuration;
+                transform.localScale = Vector3.Lerp(targetScale, originalScale, t);
+                yield return null;
+            }
+
+            transform.localScale = originalScale;
+        }
+
+        /// <summary>
+        /// Force refresh the display. Call this after loading a save.
+        /// </summary>
+        public void Refresh()
+        {
+            if (gameState != null)
+            {
+                UpdateDisplay(gameState.currentEnergy, gameState.maxEnergy);
+            }
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/UI/EnergyHUD.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/UI/EnergyHUD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c5d1e0f3a4b6c7d8e9f0a1b2c3d4e5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/UI/InventoryHUD.cs
+++ b/UnityProject/Assets/_Project/Scripts/UI/InventoryHUD.cs
@@ -1,0 +1,226 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Player;
+
+namespace WildsOfCloverhollow.UI
+{
+    /// <summary>
+    /// Displays inventory counts (gems, candy bars) in the HUD.
+    /// Provides a "Use Candy" button that consumes a candy bar to restore energy.
+    /// </summary>
+    public class InventoryHUD : MonoBehaviour
+    {
+        [Header("Gem Display")]
+        [SerializeField] private TextMeshProUGUI gemCountText;
+        [SerializeField] private Image gemIcon;
+
+        [Header("Candy Display")]
+        [SerializeField] private TextMeshProUGUI candyCountText;
+        [SerializeField] private Image candyIcon;
+        [SerializeField] private Button useCandyButton;
+        [SerializeField] private TextMeshProUGUI useCandyButtonText;
+
+        [Header("Animation")]
+        [SerializeField] private float popScale = 1.2f;
+        [SerializeField] private float popDuration = 0.15f;
+
+        private GameState gameState;
+        private CandyConsumption candyConsumption;
+
+        private int lastGemCount = -1;
+        private int lastCandyCount = -1;
+
+        private void Start()
+        {
+            // Find candy consumption component
+            candyConsumption = FindAnyObjectByType<CandyConsumption>();
+
+            // Subscribe to inventory changes
+            if (GameStateManager.Instance != null)
+            {
+                gameState = GameStateManager.Current;
+                gameState.OnInventoryChanged += OnInventoryChanged;
+                gameState.OnEnergyChanged += OnEnergyChanged;
+
+                // Initial update
+                UpdateDisplay();
+            }
+            else
+            {
+                Debug.LogWarning("[InventoryHUD] GameStateManager not found. Inventory display will not update.");
+            }
+
+            // Set up candy button
+            if (useCandyButton != null)
+            {
+                useCandyButton.onClick.AddListener(OnUseCandyClicked);
+            }
+
+            UpdateCandyButtonState();
+        }
+
+        private void OnDestroy()
+        {
+            if (gameState != null)
+            {
+                gameState.OnInventoryChanged -= OnInventoryChanged;
+                gameState.OnEnergyChanged -= OnEnergyChanged;
+            }
+
+            if (useCandyButton != null)
+            {
+                useCandyButton.onClick.RemoveListener(OnUseCandyClicked);
+            }
+        }
+
+        private void OnInventoryChanged()
+        {
+            UpdateDisplay();
+        }
+
+        private void OnEnergyChanged(int current, int max)
+        {
+            // Update button state when energy changes (might enable if not full anymore)
+            UpdateCandyButtonState();
+        }
+
+        private void UpdateDisplay()
+        {
+            if (gameState == null) return;
+
+            // Update gem count
+            if (gemCountText != null)
+            {
+                gemCountText.text = gameState.gems.ToString();
+
+                // Pop animation when gems increase
+                if (gameState.gems > lastGemCount && lastGemCount >= 0)
+                {
+                    TriggerPop(gemCountText.transform);
+                }
+            }
+
+            // Update candy count
+            if (candyCountText != null)
+            {
+                candyCountText.text = gameState.candyBars.ToString();
+
+                // Pop animation when candy increases
+                if (gameState.candyBars > lastCandyCount && lastCandyCount >= 0)
+                {
+                    TriggerPop(candyCountText.transform);
+                }
+            }
+
+            lastGemCount = gameState.gems;
+            lastCandyCount = gameState.candyBars;
+
+            UpdateCandyButtonState();
+        }
+
+        private void UpdateCandyButtonState()
+        {
+            if (useCandyButton == null || gameState == null) return;
+
+            // Button is only enabled if we have candy AND energy is not full
+            bool canUseCandy = gameState.candyBars > 0 && !gameState.IsFullEnergy;
+            useCandyButton.interactable = canUseCandy;
+
+            // Update button text if needed
+            if (useCandyButtonText != null)
+            {
+                if (gameState.candyBars <= 0)
+                {
+                    useCandyButtonText.text = "No Candy";
+                }
+                else if (gameState.IsFullEnergy)
+                {
+                    useCandyButtonText.text = "Full!";
+                }
+                else
+                {
+                    useCandyButtonText.text = "Use Candy";
+                }
+            }
+        }
+
+        private void OnUseCandyClicked()
+        {
+            if (candyConsumption != null)
+            {
+                candyConsumption.TryConsumeCandy();
+            }
+            else
+            {
+                // Fallback: directly consume if no CandyConsumption component found
+                TryConsumeDirectly();
+            }
+        }
+
+        private void TryConsumeDirectly()
+        {
+            if (gameState == null) return;
+
+            if (gameState.IsFullEnergy)
+            {
+                Debug.Log("[InventoryHUD] Cannot use candy - energy is full!");
+                return;
+            }
+
+            if (gameState.TryConsumeCandyBar())
+            {
+                // Default restore amount if no tuning available
+                gameState.RestoreEnergy(25);
+                Debug.Log("[InventoryHUD] Consumed candy bar directly, restored 25 energy.");
+            }
+        }
+
+        private void TriggerPop(Transform target)
+        {
+            if (target == null) return;
+            StartCoroutine(PopCoroutine(target));
+        }
+
+        private System.Collections.IEnumerator PopCoroutine(Transform target)
+        {
+            Vector3 originalScale = Vector3.one;
+            Vector3 targetScale = originalScale * popScale;
+
+            float elapsed = 0f;
+            float halfDuration = popDuration * 0.5f;
+
+            // Scale up
+            while (elapsed < halfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / halfDuration;
+                target.localScale = Vector3.Lerp(originalScale, targetScale, t);
+                yield return null;
+            }
+
+            // Scale down
+            elapsed = 0f;
+            while (elapsed < halfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / halfDuration;
+                target.localScale = Vector3.Lerp(targetScale, originalScale, t);
+                yield return null;
+            }
+
+            target.localScale = originalScale;
+        }
+
+        /// <summary>
+        /// Force refresh the display. Call this after loading a save.
+        /// </summary>
+        public void Refresh()
+        {
+            lastGemCount = -1;
+            lastCandyCount = -1;
+            UpdateDisplay();
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/UI/InventoryHUD.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/UI/InventoryHUD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6e2f1a4b5c6d7e8f9a0b1c2d3e4f5a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/World/CandyBarPickup.cs
+++ b/UnityProject/Assets/_Project/Scripts/World/CandyBarPickup.cs
@@ -1,0 +1,103 @@
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Interaction;
+
+namespace WildsOfCloverhollow.World
+{
+    /// <summary>
+    /// A candy bar pickup that can be collected by the player.
+    /// Implements IInteractable for the interaction system.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class CandyBarPickup : MonoBehaviour, IInteractable
+    {
+        [Header("Pickup Settings")]
+        [SerializeField] private int candyAmount = 1;
+        [SerializeField] private string interactionPrompt = "Pick up Candy Bar";
+
+        [Header("Audio (Optional)")]
+        [SerializeField] private AudioClip pickupSound;
+
+        [Header("VFX (Optional)")]
+        [SerializeField] private GameObject pickupVFXPrefab;
+
+        [Header("Animation")]
+        [SerializeField] private bool bobUpDown = true;
+        [SerializeField] private float bobSpeed = 2f;
+        [SerializeField] private float bobHeight = 0.1f;
+        [SerializeField] private bool rotate = true;
+        [SerializeField] private float rotateSpeed = 90f;
+
+        private Vector3 startPosition;
+        private bool isCollected = false;
+
+        public Transform Transform => transform;
+
+        private void Start()
+        {
+            startPosition = transform.position;
+        }
+
+        private void Update()
+        {
+            if (isCollected) return;
+
+            // Bobbing animation
+            if (bobUpDown)
+            {
+                float newY = startPosition.y + Mathf.Sin(Time.time * bobSpeed) * bobHeight;
+                transform.position = new Vector3(transform.position.x, newY, transform.position.z);
+            }
+
+            // Rotation animation
+            if (rotate)
+            {
+                transform.Rotate(Vector3.up, rotateSpeed * Time.deltaTime);
+            }
+        }
+
+        public string GetInteractionPrompt()
+        {
+            return interactionPrompt;
+        }
+
+        public bool CanInteract(GameObject interactor)
+        {
+            return !isCollected;
+        }
+
+        public void Interact(GameObject interactor)
+        {
+            if (isCollected) return;
+
+            isCollected = true;
+
+            // Add candy to inventory
+            var gameState = GameStateManager.Current;
+            if (gameState != null)
+            {
+                gameState.AddCandyBars(candyAmount);
+                Debug.Log($"[CandyBarPickup] Picked up {candyAmount} candy bar(s). Total: {gameState.candyBars}");
+            }
+            else
+            {
+                Debug.LogWarning("[CandyBarPickup] No GameState found!");
+            }
+
+            // Play pickup sound
+            if (pickupSound != null)
+            {
+                AudioSource.PlayClipAtPoint(pickupSound, transform.position);
+            }
+
+            // Spawn VFX
+            if (pickupVFXPrefab != null)
+            {
+                Instantiate(pickupVFXPrefab, transform.position, Quaternion.identity);
+            }
+
+            // Destroy the pickup
+            Destroy(gameObject);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/World/CandyBarPickup.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/World/CandyBarPickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8a4b3c6d7e8f9a0b1c2d3e4f5a6b7c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/_Project/Scripts/World/GemPickup.cs
+++ b/UnityProject/Assets/_Project/Scripts/World/GemPickup.cs
@@ -1,0 +1,139 @@
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Interaction;
+
+namespace WildsOfCloverhollow.World
+{
+    /// <summary>
+    /// A gem pickup that can be collected by the player.
+    /// Implements IInteractable for the interaction system.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class GemPickup : MonoBehaviour, IInteractable
+    {
+        public enum GemSize
+        {
+            Small,   // 5 gems
+            Medium,  // 15 gems
+            Large    // 50 gems
+        }
+
+        [Header("Pickup Settings")]
+        [SerializeField] private GemSize gemSize = GemSize.Small;
+        [SerializeField] private int customAmount = 0; // If > 0, overrides gemSize
+
+        [Header("Audio (Optional)")]
+        [SerializeField] private AudioClip pickupSound;
+
+        [Header("VFX (Optional)")]
+        [SerializeField] private GameObject pickupVFXPrefab;
+
+        [Header("Animation")]
+        [SerializeField] private bool bobUpDown = true;
+        [SerializeField] private float bobSpeed = 2f;
+        [SerializeField] private float bobHeight = 0.1f;
+        [SerializeField] private bool rotate = true;
+        [SerializeField] private float rotateSpeed = 90f;
+
+        private Vector3 startPosition;
+        private bool isCollected = false;
+
+        public Transform Transform => transform;
+
+        private int GemAmount
+        {
+            get
+            {
+                if (customAmount > 0) return customAmount;
+
+                return gemSize switch
+                {
+                    GemSize.Small => 5,
+                    GemSize.Medium => 15,
+                    GemSize.Large => 50,
+                    _ => 5
+                };
+            }
+        }
+
+        private void Start()
+        {
+            startPosition = transform.position;
+        }
+
+        private void Update()
+        {
+            if (isCollected) return;
+
+            // Bobbing animation
+            if (bobUpDown)
+            {
+                float newY = startPosition.y + Mathf.Sin(Time.time * bobSpeed) * bobHeight;
+                transform.position = new Vector3(transform.position.x, newY, transform.position.z);
+            }
+
+            // Rotation animation
+            if (rotate)
+            {
+                transform.Rotate(Vector3.up, rotateSpeed * Time.deltaTime);
+            }
+        }
+
+        public string GetInteractionPrompt()
+        {
+            string sizeLabel = gemSize switch
+            {
+                GemSize.Small => "Small",
+                GemSize.Medium => "Medium",
+                GemSize.Large => "Large",
+                _ => ""
+            };
+
+            if (customAmount > 0)
+            {
+                return $"Pick up Gems (+{customAmount})";
+            }
+
+            return $"Pick up {sizeLabel} Gem (+{GemAmount})";
+        }
+
+        public bool CanInteract(GameObject interactor)
+        {
+            return !isCollected;
+        }
+
+        public void Interact(GameObject interactor)
+        {
+            if (isCollected) return;
+
+            isCollected = true;
+
+            // Add gems to inventory
+            var gameState = GameStateManager.Current;
+            if (gameState != null)
+            {
+                gameState.AddGems(GemAmount);
+                Debug.Log($"[GemPickup] Picked up {GemAmount} gems. Total: {gameState.gems}");
+            }
+            else
+            {
+                Debug.LogWarning("[GemPickup] No GameState found!");
+            }
+
+            // Play pickup sound
+            if (pickupSound != null)
+            {
+                AudioSource.PlayClipAtPoint(pickupSound, transform.position);
+            }
+
+            // Spawn VFX
+            if (pickupVFXPrefab != null)
+            {
+                Instantiate(pickupVFXPrefab, transform.position, Quaternion.identity);
+            }
+
+            // Destroy the pickup
+            Destroy(gameObject);
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/World/GemPickup.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/World/GemPickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9b5c4d7e8f9a0b1c2d3e4f5a6b7c8d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
Implements the energy system and candy bar consumption for the PoC, as specified in Issue #20.

Closes #20

## Changes
- **EnergyTuning.cs** - ScriptableObject for tuning max energy, candy restore amount, tired threshold, and respawn energy percent
- **EnergyHUD.cs** - Displays current energy as hearts (up to 5) or as a fill bar. Subscribes to GameState.OnEnergyChanged
- **InventoryHUD.cs** - Shows gem and candy bar counts with icons. Provides "Use Candy" button (disabled when candy=0 or energy=max)
- **CandyConsumption.cs** - Handles candy bar consumption logic with sound/VFX feedback placeholders
- **CandyBarPickup.cs** - IInteractable pickup that adds candy bars to inventory
- **GemPickup.cs** - IInteractable pickup with configurable gem amounts (Small=5, Medium=15, Large=50)
- **EnergyTuning.asset** - Default tuning values (maxEnergy=100, candyRestore=25)

## Integration
All components integrate with existing GameState events:
- OnEnergyChanged for HUD updates
- OnInventoryChanged for inventory display
- TryConsumeCandyBar() and RestoreEnergy() for consumption

## Acceptance Criteria
- [x] Energy display in HUD (hearts or bar)
- [x] Candy bar count in HUD
- [x] Use Candy button (enabled when candy > 0 AND energy < max)
- [x] Gem count in HUD
- [x] Pickups implement IInteractable
- [x] Fixed candy restore amount (25, configurable via EnergyTuning)
- [x] Scripts compile without errors