### PR TITLE
feat: Add Maddie follower and combat assist

### DIFF
--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieAssist.cs
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieAssist.cs
@@ -1,0 +1,156 @@
+using System.Collections;
+using UnityEngine;
+using WildsOfCloverhollow.Combat;
+
+namespace WildsOfCloverhollow.AI
+{
+    /// <summary>
+    /// Controls Maddie's combat assist behavior.
+    /// Subscribes to CombatEvents and performs dash attacks on enemies.
+    /// </summary>
+    [RequireComponent(typeof(MaddieFollower))]
+    public class MaddieAssist : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private MaddieTuning tuning;
+        [SerializeField] private MaddieVFX vfx;
+
+        private MaddieFollower follower;
+        private float cooldownTimer;
+        private bool isAssisting;
+        private GameObject currentTarget;
+
+        /// <summary>
+        /// Gets whether Maddie is currently performing an assist attack.
+        /// </summary>
+        public bool IsAssisting => isAssisting;
+
+        private void Awake()
+        {
+            follower = GetComponent<MaddieFollower>();
+
+            if (tuning == null)
+            {
+                Debug.LogError("[MaddieAssist] MaddieTuning reference is missing!");
+            }
+        }
+
+        private void OnEnable()
+        {
+            CombatEvents.OnEnemyEngaged += HandleEnemyEngaged;
+            CombatEvents.OnEnemyDefeated += HandleEnemyDefeated;
+        }
+
+        private void OnDisable()
+        {
+            CombatEvents.OnEnemyEngaged -= HandleEnemyEngaged;
+            CombatEvents.OnEnemyDefeated -= HandleEnemyDefeated;
+        }
+
+        private void Update()
+        {
+            if (cooldownTimer > 0f)
+            {
+                cooldownTimer -= Time.deltaTime;
+            }
+        }
+
+        private void HandleEnemyEngaged(GameObject enemy)
+        {
+            if (tuning == null || isAssisting) return;
+            if (cooldownTimer > 0f) return;
+            if (enemy == null) return;
+
+            // Start assist attack
+            currentTarget = enemy;
+            StartCoroutine(PerformAssistAttack(enemy));
+        }
+
+        private void HandleEnemyDefeated(GameObject enemy)
+        {
+            // If we were targeting this enemy, cancel the assist
+            if (currentTarget == enemy)
+            {
+                currentTarget = null;
+                // The coroutine will handle the null check
+            }
+        }
+
+        private IEnumerator PerformAssistAttack(GameObject enemy)
+        {
+            isAssisting = true;
+            follower.IsFollowing = false;
+
+            // Store starting position
+            Vector3 startPosition = transform.position;
+
+            // Dash toward enemy
+            while (enemy != null && currentTarget != null)
+            {
+                Vector3 targetPos = enemy.transform.position;
+                float distanceToEnemy = Vector3.Distance(transform.position, targetPos);
+
+                if (distanceToEnemy <= tuning.AssistAttackRange)
+                {
+                    break;
+                }
+
+                // Move toward enemy
+                Vector3 direction = (targetPos - transform.position).normalized;
+                transform.position += direction * tuning.AssistDashSpeed * Time.deltaTime;
+
+                // Face enemy
+                if (direction.sqrMagnitude > 0.01f)
+                {
+                    Vector3 horizontalDir = new Vector3(direction.x, 0f, direction.z);
+                    if (horizontalDir.sqrMagnitude > 0.01f)
+                    {
+                        transform.rotation = Quaternion.LookRotation(horizontalDir);
+                    }
+                }
+
+                yield return null;
+            }
+
+            // Apply damage if enemy still exists
+            if (enemy != null && currentTarget != null)
+            {
+                var damageable = enemy.GetComponent<IDamageable>();
+                if (damageable != null && damageable.IsAlive)
+                {
+                    damageable.ApplyDamage(tuning.AssistDamage, transform.position);
+                    CombatEvents.RaiseDamageDealt(enemy, tuning.AssistDamage);
+
+                    // Trigger VFX
+                    if (vfx != null)
+                    {
+                        vfx.PlayAssistEffect();
+                    }
+
+                    Debug.Log($"[MaddieAssist] Dealt {tuning.AssistDamage} damage to {enemy.name}");
+                }
+            }
+
+            // Linger briefly at attack position
+            yield return new WaitForSeconds(tuning.AssistLingerTime);
+
+            // Start cooldown
+            cooldownTimer = tuning.AssistCooldown;
+            currentTarget = null;
+
+            // Resume following
+            isAssisting = false;
+            follower.IsFollowing = true;
+        }
+
+        /// <summary>
+        /// Gets the remaining cooldown time in seconds.
+        /// </summary>
+        public float RemainingCooldown => Mathf.Max(0f, cooldownTimer);
+
+        /// <summary>
+        /// Returns true if assist is ready to trigger.
+        /// </summary>
+        public bool IsReady => cooldownTimer <= 0f && !isAssisting;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieAssist.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieAssist.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b614fafa52f64895a66486533d33f93

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieFollower.cs
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieFollower.cs
@@ -1,0 +1,187 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.AI
+{
+    /// <summary>
+    /// Controls Maddie's following behavior.
+    /// Uses spring/arrive steering to smoothly follow the player.
+    /// </summary>
+    public class MaddieFollower : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private MaddieTuning tuning;
+
+        private Transform playerTarget;
+        private Vector3 currentVelocity;
+        private bool isFollowing = true;
+
+        /// <summary>
+        /// Gets or sets whether Maddie is actively following the player.
+        /// Set to false during assist attacks.
+        /// </summary>
+        public bool IsFollowing
+        {
+            get => isFollowing;
+            set => isFollowing = value;
+        }
+
+        /// <summary>
+        /// Gets the player transform that Maddie is following.
+        /// </summary>
+        public Transform PlayerTarget => playerTarget;
+
+        private void Awake()
+        {
+            if (tuning == null)
+            {
+                Debug.LogError("[MaddieFollower] MaddieTuning reference is missing!");
+            }
+        }
+
+        private void Start()
+        {
+            FindPlayer();
+        }
+
+        private void Update()
+        {
+            if (tuning == null) return;
+
+            if (playerTarget == null)
+            {
+                FindPlayer();
+                return;
+            }
+
+            if (isFollowing)
+            {
+                UpdateFollowing();
+            }
+
+            CheckTeleportDistance();
+        }
+
+        private void FindPlayer()
+        {
+            var player = GameObject.FindGameObjectWithTag("Player");
+            if (player != null)
+            {
+                playerTarget = player.transform;
+            }
+        }
+
+        private void UpdateFollowing()
+        {
+            Vector3 targetPosition = GetFollowTargetPosition();
+            float distanceToTarget = Vector3.Distance(transform.position, targetPosition);
+
+            // Stop if close enough
+            if (distanceToTarget < tuning.MinDistance)
+            {
+                currentVelocity = Vector3.Lerp(currentVelocity, Vector3.zero, tuning.FollowSmoothness * Time.deltaTime);
+                return;
+            }
+
+            // Calculate desired velocity
+            Vector3 directionToTarget = (targetPosition - transform.position).normalized;
+            Vector3 desiredVelocity = directionToTarget * tuning.FollowSpeed;
+
+            // Smooth velocity change (spring-like behavior)
+            currentVelocity = Vector3.Lerp(currentVelocity, desiredVelocity, tuning.FollowSmoothness * Time.deltaTime);
+
+            // Apply movement
+            transform.position += currentVelocity * Time.deltaTime;
+
+            // Face movement direction
+            if (currentVelocity.sqrMagnitude > 0.01f)
+            {
+                Vector3 horizontalVelocity = new Vector3(currentVelocity.x, 0f, currentVelocity.z);
+                if (horizontalVelocity.sqrMagnitude > 0.01f)
+                {
+                    Quaternion targetRotation = Quaternion.LookRotation(horizontalVelocity);
+                    transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, tuning.FollowSmoothness * Time.deltaTime);
+                }
+            }
+        }
+
+        private Vector3 GetFollowTargetPosition()
+        {
+            if (playerTarget == null) return transform.position;
+
+            // Calculate offset position behind and to the side of player
+            Vector3 playerBack = -playerTarget.forward;
+            Vector3 playerRight = playerTarget.right;
+
+            // Apply angle offset
+            float angleRad = tuning.FollowAngleOffset * Mathf.Deg2Rad;
+            Vector3 offsetDirection = playerBack * Mathf.Cos(angleRad) + playerRight * Mathf.Sin(angleRad);
+            offsetDirection.y = 0f;
+            offsetDirection.Normalize();
+
+            Vector3 targetPos = playerTarget.position + offsetDirection * tuning.FollowDistance;
+            targetPos.y = playerTarget.position.y; // Stay at player height
+
+            return targetPos;
+        }
+
+        private void CheckTeleportDistance()
+        {
+            if (playerTarget == null) return;
+
+            float distanceToPlayer = Vector3.Distance(transform.position, playerTarget.position);
+            if (distanceToPlayer > tuning.TeleportDistance)
+            {
+                TeleportToPlayer();
+            }
+        }
+
+        /// <summary>
+        /// Instantly teleport Maddie to the player's follow position.
+        /// Called when too far away or during scene transitions.
+        /// </summary>
+        public void TeleportToPlayer()
+        {
+            if (playerTarget == null)
+            {
+                FindPlayer();
+                if (playerTarget == null) return;
+            }
+
+            Vector3 targetPos = GetFollowTargetPosition();
+            transform.position = targetPos;
+            currentVelocity = Vector3.zero;
+
+            Debug.Log("[MaddieFollower] Teleported to player.");
+        }
+
+        /// <summary>
+        /// Set the player target manually (useful for initialization).
+        /// </summary>
+        public void SetPlayerTarget(Transform player)
+        {
+            playerTarget = player;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (tuning == null) return;
+
+            // Draw follow distance
+            Gizmos.color = Color.cyan;
+            Gizmos.DrawWireSphere(transform.position, tuning.MinDistance);
+
+            // Draw teleport distance
+            Gizmos.color = new Color(1f, 0.5f, 0f, 0.3f);
+            Gizmos.DrawWireSphere(transform.position, tuning.TeleportDistance);
+
+            // Draw target position if player exists
+            if (playerTarget != null)
+            {
+                Vector3 targetPos = GetFollowTargetPosition();
+                Gizmos.color = Color.green;
+                Gizmos.DrawSphere(targetPos, 0.2f);
+                Gizmos.DrawLine(transform.position, targetPos);
+            }
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieFollower.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieFollower.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d68f01d5ac734571847e7d567c91996

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieTuning.cs
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieTuning.cs
@@ -1,0 +1,73 @@
+using UnityEngine;
+
+namespace WildsOfCloverhollow.AI
+{
+    /// <summary>
+    /// Tuning values for Maddie the kitten companion.
+    /// Covers following behavior, combat assist, and visual feedback.
+    /// </summary>
+    [CreateAssetMenu(fileName = "MaddieTuning", menuName = "CloverWilds/Tuning/MaddieTuning")]
+    public class MaddieTuning : ScriptableObject
+    {
+        [Header("Following")]
+        [Tooltip("Movement speed when following the player")]
+        [SerializeField] private float followSpeed = 5f;
+
+        [Tooltip("Preferred distance behind/beside the player")]
+        [SerializeField] private float followDistance = 2f;
+
+        [Tooltip("Stop moving when this close to target position")]
+        [SerializeField] private float minDistance = 1f;
+
+        [Tooltip("Teleport to player if further than this distance")]
+        [SerializeField] private float teleportDistance = 15f;
+
+        [Tooltip("Smoothing factor for movement (higher = snappier)")]
+        [SerializeField] private float followSmoothness = 8f;
+
+        [Tooltip("Offset angle from player's back (0 = directly behind, 45 = beside)")]
+        [SerializeField] private float followAngleOffset = 30f;
+
+        [Header("Combat Assist")]
+        [Tooltip("Damage dealt by assist attack")]
+        [SerializeField] private int assistDamage = 5;
+
+        [Tooltip("Cooldown between assist attacks in seconds")]
+        [SerializeField] private float assistCooldown = 3f;
+
+        [Tooltip("Speed of dash toward enemy during assist")]
+        [SerializeField] private float assistDashSpeed = 10f;
+
+        [Tooltip("Distance to stop from enemy when attacking")]
+        [SerializeField] private float assistAttackRange = 0.8f;
+
+        [Tooltip("Duration to linger at enemy before returning")]
+        [SerializeField] private float assistLingerTime = 0.3f;
+
+        [Header("Visual Feedback")]
+        [Tooltip("Vertical bob amplitude when idle")]
+        [SerializeField] private float idleBobAmount = 0.1f;
+
+        [Tooltip("Vertical bob speed when idle")]
+        [SerializeField] private float idleBobSpeed = 2f;
+
+        // Following properties
+        public float FollowSpeed => followSpeed;
+        public float FollowDistance => followDistance;
+        public float MinDistance => minDistance;
+        public float TeleportDistance => teleportDistance;
+        public float FollowSmoothness => followSmoothness;
+        public float FollowAngleOffset => followAngleOffset;
+
+        // Combat assist properties
+        public int AssistDamage => assistDamage;
+        public float AssistCooldown => assistCooldown;
+        public float AssistDashSpeed => assistDashSpeed;
+        public float AssistAttackRange => assistAttackRange;
+        public float AssistLingerTime => assistLingerTime;
+
+        // Visual feedback properties
+        public float IdleBobAmount => idleBobAmount;
+        public float IdleBobSpeed => idleBobSpeed;
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieTuning.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieTuning.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11fdca23b9f3c4bfc90c346edea01366

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieVFX.cs
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieVFX.cs
@@ -1,0 +1,139 @@
+using System.Collections;
+using UnityEngine;
+
+namespace WildsOfCloverhollow.AI
+{
+    /// <summary>
+    /// Handles visual effects and animations for Maddie.
+    /// Includes idle bobbing and assist attack effects.
+    /// </summary>
+    public class MaddieVFX : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private MaddieTuning tuning;
+        [SerializeField] private Transform visualRoot;
+        [SerializeField] private Renderer maddieRenderer;
+        [SerializeField] private ParticleSystem assistPuffParticle;
+
+        [Header("Audio (Placeholder)")]
+        [SerializeField] private AudioSource audioSource;
+        [SerializeField] private AudioClip assistSoundClip;
+
+        private Vector3 visualRootBasePosition;
+        private float bobPhase;
+        private MaddieFollower follower;
+        private MaddieAssist assist;
+
+        private void Awake()
+        {
+            follower = GetComponent<MaddieFollower>();
+            assist = GetComponent<MaddieAssist>();
+
+            if (visualRoot != null)
+            {
+                visualRootBasePosition = visualRoot.localPosition;
+            }
+
+            if (tuning == null)
+            {
+                Debug.LogWarning("[MaddieVFX] MaddieTuning reference is missing. Idle bob disabled.");
+            }
+        }
+
+        private void Update()
+        {
+            UpdateIdleBob();
+        }
+
+        private void UpdateIdleBob()
+        {
+            if (tuning == null || visualRoot == null) return;
+
+            // Only bob when idle (not moving fast or assisting)
+            bool shouldBob = true;
+            if (assist != null && assist.IsAssisting)
+            {
+                shouldBob = false;
+            }
+
+            if (shouldBob)
+            {
+                bobPhase += Time.deltaTime * tuning.IdleBobSpeed;
+                float bobOffset = Mathf.Sin(bobPhase * Mathf.PI * 2f) * tuning.IdleBobAmount;
+                visualRoot.localPosition = visualRootBasePosition + Vector3.up * bobOffset;
+            }
+            else
+            {
+                // Smoothly return to base position
+                visualRoot.localPosition = Vector3.Lerp(
+                    visualRoot.localPosition,
+                    visualRootBasePosition,
+                    10f * Time.deltaTime
+                );
+            }
+        }
+
+        /// <summary>
+        /// Play the assist attack effect (puff + flash + sound).
+        /// Called by MaddieAssist when damage is dealt.
+        /// </summary>
+        public void PlayAssistEffect()
+        {
+            // Puff particle
+            if (assistPuffParticle != null)
+            {
+                assistPuffParticle.Play();
+            }
+
+            // Color flash
+            if (maddieRenderer != null)
+            {
+                StartCoroutine(AssistFlashCoroutine());
+            }
+
+            // Sound cue
+            if (audioSource != null && assistSoundClip != null)
+            {
+                audioSource.PlayOneShot(assistSoundClip);
+            }
+            else
+            {
+                // Placeholder: log that sound would play
+                Debug.Log("[MaddieVFX] Assist sound cue (placeholder)");
+            }
+        }
+
+        private IEnumerator AssistFlashCoroutine()
+        {
+            if (maddieRenderer == null) yield break;
+
+            // Flash to a bright color briefly
+            Color originalColor = maddieRenderer.material.color;
+            Color flashColor = new Color(1f, 0.9f, 0.5f); // Warm yellow flash
+
+            maddieRenderer.material.color = flashColor;
+            yield return new WaitForSeconds(0.1f);
+            maddieRenderer.material.color = originalColor;
+        }
+
+        /// <summary>
+        /// Set up references at runtime if needed.
+        /// </summary>
+        public void SetVisualRoot(Transform root)
+        {
+            visualRoot = root;
+            if (visualRoot != null)
+            {
+                visualRootBasePosition = visualRoot.localPosition;
+            }
+        }
+
+        /// <summary>
+        /// Set the renderer reference at runtime if needed.
+        /// </summary>
+        public void SetRenderer(Renderer renderer)
+        {
+            maddieRenderer = renderer;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Scripts/AI/MaddieVFX.cs.meta
+++ b/UnityProject/Assets/_Project/Scripts/AI/MaddieVFX.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50158f05823b3426f85d9d019eca2a1c


### PR DESCRIPTION
## Summary

Closes #22

Implements Maddie the kitten companion with smooth following and combat assist capabilities.

## Changes

- **MaddieTuning.cs**: ScriptableObject with configurable values for following, combat assist, and visual feedback
- **MaddieFollower.cs**: Spring-based player following with teleport safety for scene transitions
- **MaddieAssist.cs**: Combat assist that subscribes to CombatEvents.OnEnemyEngaged and performs dash attacks
- **MaddieVFX.cs**: Visual feedback including idle bobbing and assist attack effects (flash + puff)

## Key Behaviors

1. **Following**: Maddie stays behind/beside the player with smooth spring steering
2. **Teleport Safety**: Automatically teleports to player if too far (>15 units) - handles scene transitions
3. **Combat Assist**: On enemy engagement, Maddie dashes to enemy, deals 5 damage, then returns
4. **Cooldown**: 3 second cooldown between assists (prevents Maddie from soloing enemies)

## Tuning Defaults

| Parameter | Value |
|-----------|-------|
| Follow Speed | 5 |
| Follow Distance | 2 |
| Min Distance | 1 |
| Teleport Distance | 15 |
| Assist Damage | 5 |
| Assist Cooldown | 3s |
| Assist Dash Speed | 10 |

## Prefab Setup (Manual Step Required)

To create Maddie prefab in Unity:
1. Create empty GameObject named "Maddie"
2. Add child sphere/capsule for visual (small, ~0.3 scale)
3. Add MaddieFollower, MaddieAssist, MaddieVFX components
4. Create MaddieTuning asset: Right-click → Create → CloverWilds → Tuning → MaddieTuning
5. Assign tuning reference to all components
6. Optionally add particle system child for assist puff effect

## Testing

- [x] Scripts compile without errors (verified with Unity batchmode)
- [ ] MaddieFollower smoothly follows player
- [ ] MaddieAssist triggers on enemy engagement
- [ ] Assist damage is 5 with 3s cooldown
- [ ] Maddie does not block player movement