### PR TITLE
feat: Add QA automated checks and regression checklist

### DIFF
--- a/UnityProject/Assets/_Project/Tests/EditMode/GameStateTests.cs
+++ b/UnityProject/Assets/_Project/Tests/EditMode/GameStateTests.cs
@@ -1,0 +1,534 @@
+using NUnit.Framework;
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+
+namespace WildsOfCloverhollow.Tests
+{
+    public class GameStateTests
+    {
+        #region Story Flags
+
+        [Test]
+        public void AddStoryFlag_NewFlag_AddsSuccessfully()
+        {
+            var state = new GameState();
+            
+            state.AddStoryFlag("Test.Flag");
+            
+            Assert.IsTrue(state.HasStoryFlag("Test.Flag"));
+        }
+
+        [Test]
+        public void AddStoryFlag_DuplicateFlag_DoesNotDuplicate()
+        {
+            var state = new GameState();
+            state.AddStoryFlag("Test.Flag");
+            
+            state.AddStoryFlag("Test.Flag");
+            
+            Assert.AreEqual(1, state.storyFlags.Count);
+        }
+
+        [Test]
+        public void AddStoryFlag_FiresEvent()
+        {
+            var state = new GameState();
+            string receivedFlag = null;
+            state.OnStoryFlagAdded += flag => receivedFlag = flag;
+            
+            state.AddStoryFlag("Test.Flag");
+            
+            Assert.AreEqual("Test.Flag", receivedFlag);
+        }
+
+        [Test]
+        public void AddStoryFlag_DuplicateFlag_DoesNotFireEvent()
+        {
+            var state = new GameState();
+            state.AddStoryFlag("Test.Flag");
+            int eventCount = 0;
+            state.OnStoryFlagAdded += _ => eventCount++;
+            
+            state.AddStoryFlag("Test.Flag");
+            
+            Assert.AreEqual(0, eventCount);
+        }
+
+        [Test]
+        public void RemoveStoryFlag_ExistingFlag_RemovesSuccessfully()
+        {
+            var state = new GameState();
+            state.AddStoryFlag("Test.Flag");
+            
+            state.RemoveStoryFlag("Test.Flag");
+            
+            Assert.IsFalse(state.HasStoryFlag("Test.Flag"));
+        }
+
+        [Test]
+        public void HasStoryFlag_NonExistentFlag_ReturnsFalse()
+        {
+            var state = new GameState();
+            
+            Assert.IsFalse(state.HasStoryFlag("NonExistent"));
+        }
+
+        #endregion
+
+        #region Notes
+
+        [Test]
+        public void DiscoverNote_NewNote_AddsSuccessfully()
+        {
+            var state = new GameState();
+            
+            state.DiscoverNote("note-1");
+            
+            Assert.IsTrue(state.HasDiscoveredNote("note-1"));
+        }
+
+        [Test]
+        public void DiscoverNote_FiresEvent()
+        {
+            var state = new GameState();
+            string receivedNoteId = null;
+            state.OnNoteDiscovered += id => receivedNoteId = id;
+            
+            state.DiscoverNote("note-1");
+            
+            Assert.AreEqual("note-1", receivedNoteId);
+        }
+
+        [Test]
+        public void DiscoverNote_DuplicateNote_DoesNotFireEvent()
+        {
+            var state = new GameState();
+            state.DiscoverNote("note-1");
+            int eventCount = 0;
+            state.OnNoteDiscovered += _ => eventCount++;
+            
+            state.DiscoverNote("note-1");
+            
+            Assert.AreEqual(0, eventCount);
+        }
+
+        #endregion
+
+        #region Doors
+
+        [Test]
+        public void RevealDoor_NewDoor_AddsSuccessfully()
+        {
+            var state = new GameState();
+            
+            state.RevealDoor("door-1");
+            
+            Assert.IsTrue(state.HasRevealedDoor("door-1"));
+        }
+
+        [Test]
+        public void RevealDoor_FiresEvent()
+        {
+            var state = new GameState();
+            string receivedDoorId = null;
+            state.OnDoorRevealed += id => receivedDoorId = id;
+            
+            state.RevealDoor("door-1");
+            
+            Assert.AreEqual("door-1", receivedDoorId);
+        }
+
+        #endregion
+
+        #region Inventory
+
+        [Test]
+        public void AddGems_PositiveAmount_IncreasesGems()
+        {
+            var state = new GameState();
+            state.gems = 10;
+            
+            state.AddGems(5);
+            
+            Assert.AreEqual(15, state.gems);
+        }
+
+        [Test]
+        public void AddGems_NegativeAmount_DecreasesGems()
+        {
+            var state = new GameState();
+            state.gems = 10;
+            
+            state.AddGems(-3);
+            
+            Assert.AreEqual(7, state.gems);
+        }
+
+        [Test]
+        public void AddGems_NegativeAmount_ClampsToZero()
+        {
+            var state = new GameState();
+            state.gems = 5;
+            
+            state.AddGems(-10);
+            
+            Assert.AreEqual(0, state.gems);
+        }
+
+        [Test]
+        public void AddGems_FiresInventoryChangedEvent()
+        {
+            var state = new GameState();
+            bool eventFired = false;
+            state.OnInventoryChanged += () => eventFired = true;
+            
+            state.AddGems(10);
+            
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void AddCandyBars_PositiveAmount_IncreasesCandyBars()
+        {
+            var state = new GameState();
+            state.candyBars = 2;
+            
+            state.AddCandyBars(3);
+            
+            Assert.AreEqual(5, state.candyBars);
+        }
+
+        [Test]
+        public void AddCandyBars_FiresInventoryChangedEvent()
+        {
+            var state = new GameState();
+            bool eventFired = false;
+            state.OnInventoryChanged += () => eventFired = true;
+            
+            state.AddCandyBars(1);
+            
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void TryConsumeCandyBar_HasCandyBars_ReturnsTrue()
+        {
+            var state = new GameState();
+            state.candyBars = 3;
+            
+            bool result = state.TryConsumeCandyBar();
+            
+            Assert.IsTrue(result);
+            Assert.AreEqual(2, state.candyBars);
+        }
+
+        [Test]
+        public void TryConsumeCandyBar_NoCandyBars_ReturnsFalse()
+        {
+            var state = new GameState();
+            state.candyBars = 0;
+            
+            bool result = state.TryConsumeCandyBar();
+            
+            Assert.IsFalse(result);
+            Assert.AreEqual(0, state.candyBars);
+        }
+
+        [Test]
+        public void TryConsumeCandyBar_FiresInventoryChangedEvent()
+        {
+            var state = new GameState();
+            state.candyBars = 1;
+            bool eventFired = false;
+            state.OnInventoryChanged += () => eventFired = true;
+            
+            state.TryConsumeCandyBar();
+            
+            Assert.IsTrue(eventFired);
+        }
+
+        #endregion
+
+        #region Energy
+
+        [Test]
+        public void SetEnergy_ValidValues_SetsCorrectly()
+        {
+            var state = new GameState();
+            
+            state.SetEnergy(50, 100);
+            
+            Assert.AreEqual(50, state.currentEnergy);
+            Assert.AreEqual(100, state.maxEnergy);
+        }
+
+        [Test]
+        public void SetEnergy_CurrentExceedsMax_ClampsToMax()
+        {
+            var state = new GameState();
+            
+            state.SetEnergy(150, 100);
+            
+            Assert.AreEqual(100, state.currentEnergy);
+        }
+
+        [Test]
+        public void SetEnergy_MaxBelowOne_ClampsToOne()
+        {
+            var state = new GameState();
+            
+            state.SetEnergy(0, 0);
+            
+            Assert.AreEqual(1, state.maxEnergy);
+        }
+
+        [Test]
+        public void SetEnergy_FiresEnergyChangedEvent()
+        {
+            var state = new GameState();
+            int receivedCurrent = -1;
+            int receivedMax = -1;
+            state.OnEnergyChanged += (current, max) =>
+            {
+                receivedCurrent = current;
+                receivedMax = max;
+            };
+            
+            state.SetEnergy(75, 100);
+            
+            Assert.AreEqual(75, receivedCurrent);
+            Assert.AreEqual(100, receivedMax);
+        }
+
+        [Test]
+        public void TakeDamage_ReducesEnergy()
+        {
+            var state = new GameState();
+            state.SetEnergy(100, 100);
+            
+            state.TakeDamage(25);
+            
+            Assert.AreEqual(75, state.currentEnergy);
+        }
+
+        [Test]
+        public void TakeDamage_ClampsToZero()
+        {
+            var state = new GameState();
+            state.SetEnergy(10, 100);
+            
+            state.TakeDamage(50);
+            
+            Assert.AreEqual(0, state.currentEnergy);
+        }
+
+        [Test]
+        public void TakeDamage_ReachesZero_FiresTiredEvent()
+        {
+            var state = new GameState();
+            state.SetEnergy(10, 100);
+            bool tiredFired = false;
+            state.OnPlayerTired += () => tiredFired = true;
+            
+            state.TakeDamage(10);
+            
+            Assert.IsTrue(tiredFired);
+        }
+
+        [Test]
+        public void TakeDamage_AlreadyAtZero_DoesNotFireTiredEvent()
+        {
+            var state = new GameState();
+            state.SetEnergy(0, 100);
+            bool tiredFired = false;
+            state.OnPlayerTired += () => tiredFired = true;
+            
+            state.TakeDamage(10);
+            
+            Assert.IsFalse(tiredFired);
+        }
+
+        [Test]
+        public void RestoreEnergy_IncreasesEnergy()
+        {
+            var state = new GameState();
+            state.SetEnergy(50, 100);
+            
+            state.RestoreEnergy(25);
+            
+            Assert.AreEqual(75, state.currentEnergy);
+        }
+
+        [Test]
+        public void RestoreEnergy_ClampsToMax()
+        {
+            var state = new GameState();
+            state.SetEnergy(90, 100);
+            
+            state.RestoreEnergy(50);
+            
+            Assert.AreEqual(100, state.currentEnergy);
+        }
+
+        [Test]
+        public void RestoreToPercentage_RestoresCorrectAmount()
+        {
+            var state = new GameState();
+            state.SetEnergy(10, 100);
+            
+            state.RestoreToPercentage(0.5f);
+            
+            Assert.AreEqual(50, state.currentEnergy);
+        }
+
+        [Test]
+        public void IsFullEnergy_AtMax_ReturnsTrue()
+        {
+            var state = new GameState();
+            state.SetEnergy(100, 100);
+            
+            Assert.IsTrue(state.IsFullEnergy);
+        }
+
+        [Test]
+        public void IsFullEnergy_BelowMax_ReturnsFalse()
+        {
+            var state = new GameState();
+            state.SetEnergy(99, 100);
+            
+            Assert.IsFalse(state.IsFullEnergy);
+        }
+
+        [Test]
+        public void IsTired_AtZero_ReturnsTrue()
+        {
+            var state = new GameState();
+            state.SetEnergy(0, 100);
+            
+            Assert.IsTrue(state.IsTired);
+        }
+
+        [Test]
+        public void IsTired_AboveZero_ReturnsFalse()
+        {
+            var state = new GameState();
+            state.SetEnergy(1, 100);
+            
+            Assert.IsFalse(state.IsTired);
+        }
+
+        #endregion
+
+        #region Tool Unlocks
+
+        [Test]
+        public void IsLanternUnlocked_NotUnlocked_ReturnsFalse()
+        {
+            var state = new GameState();
+            
+            Assert.IsFalse(state.IsLanternUnlocked);
+        }
+
+        [Test]
+        public void UnlockLantern_SetsFlag()
+        {
+            var state = new GameState();
+            
+            state.UnlockLantern();
+            
+            Assert.IsTrue(state.IsLanternUnlocked);
+            Assert.IsTrue(state.HasStoryFlag("Tool.Lantern.Unlocked"));
+        }
+
+        [Test]
+        public void IsLassoUnlocked_NotUnlocked_ReturnsFalse()
+        {
+            var state = new GameState();
+            
+            Assert.IsFalse(state.IsLassoUnlocked);
+        }
+
+        [Test]
+        public void UnlockLasso_SetsFlag()
+        {
+            var state = new GameState();
+            
+            state.UnlockLasso();
+            
+            Assert.IsTrue(state.IsLassoUnlocked);
+        }
+
+        [Test]
+        public void IsFluteUnlocked_NotUnlocked_ReturnsFalse()
+        {
+            var state = new GameState();
+            
+            Assert.IsFalse(state.IsFluteUnlocked);
+        }
+
+        [Test]
+        public void UnlockFlute_SetsFlag()
+        {
+            var state = new GameState();
+            
+            state.UnlockFlute();
+            
+            Assert.IsTrue(state.IsFluteUnlocked);
+        }
+
+        #endregion
+
+        #region Reset
+
+        [Test]
+        public void Reset_ClearsAllState()
+        {
+            var state = new GameState();
+            state.gems = 100;
+            state.candyBars = 10;
+            state.currentEnergy = 50;
+            state.currentSceneName = "TestScene";
+            state.playerPosition = new Vector3(10, 0, 10);
+            state.AddStoryFlag("Test.Flag");
+            state.DiscoverNote("test-note");
+            state.RevealDoor("test-door");
+            
+            state.Reset();
+            
+            Assert.AreEqual(0, state.gems);
+            Assert.AreEqual(0, state.candyBars);
+            Assert.AreEqual(100, state.currentEnergy);
+            Assert.AreEqual(100, state.maxEnergy);
+            Assert.AreEqual("", state.currentSceneName);
+            Assert.AreEqual(Vector3.zero, state.playerPosition);
+            Assert.AreEqual(0, state.storyFlags.Count);
+            Assert.AreEqual(0, state.discoveredNotes.Count);
+            Assert.AreEqual(0, state.revealedDoors.Count);
+        }
+
+        #endregion
+
+        #region NotifyStateLoaded
+
+        [Test]
+        public void NotifyStateLoaded_FiresAllEvents()
+        {
+            var state = new GameState();
+            state.SetEnergy(50, 100);
+            bool stateLoadedFired = false;
+            bool inventoryChangedFired = false;
+            bool energyChangedFired = false;
+            state.OnStateLoaded += () => stateLoadedFired = true;
+            state.OnInventoryChanged += () => inventoryChangedFired = true;
+            state.OnEnergyChanged += (_, _) => energyChangedFired = true;
+            
+            state.NotifyStateLoaded();
+            
+            Assert.IsTrue(stateLoadedFired);
+            Assert.IsTrue(inventoryChangedFired);
+            Assert.IsTrue(energyChangedFired);
+        }
+
+        #endregion
+    }
+}

--- a/UnityProject/Assets/_Project/Tests/EditMode/SaveDataTests.cs
+++ b/UnityProject/Assets/_Project/Tests/EditMode/SaveDataTests.cs
@@ -1,0 +1,214 @@
+using NUnit.Framework;
+using UnityEngine;
+using WildsOfCloverhollow.Core;
+using WildsOfCloverhollow.Save;
+
+namespace WildsOfCloverhollow.Tests
+{
+    public class SaveDataTests
+    {
+        [Test]
+        public void FromGameState_CreatesValidSaveData()
+        {
+            var state = CreatePopulatedGameState();
+            
+            var saveData = SaveData.FromGameState(state);
+            
+            Assert.AreEqual(SaveData.CurrentVersion, saveData.version);
+            Assert.IsNotNull(saveData.timestamp);
+            Assert.AreEqual("Cloverhollow", saveData.currentSceneName);
+            Assert.AreEqual(100, saveData.gems);
+            Assert.AreEqual(5, saveData.candyBars);
+            Assert.AreEqual(75, saveData.currentEnergy);
+            Assert.AreEqual(100, saveData.maxEnergy);
+        }
+
+        [Test]
+        public void ToGameState_RestoresAllFields()
+        {
+            var originalState = CreatePopulatedGameState();
+            var saveData = SaveData.FromGameState(originalState);
+            
+            var restoredState = saveData.ToGameState();
+            
+            Assert.AreEqual(originalState.currentSceneName, restoredState.currentSceneName);
+            Assert.AreEqual(originalState.gems, restoredState.gems);
+            Assert.AreEqual(originalState.candyBars, restoredState.candyBars);
+            Assert.AreEqual(originalState.currentEnergy, restoredState.currentEnergy);
+            Assert.AreEqual(originalState.maxEnergy, restoredState.maxEnergy);
+        }
+
+        [Test]
+        public void RoundTrip_PreservesPosition()
+        {
+            var state = new GameState
+            {
+                playerPosition = new Vector3(10.5f, 2.0f, -5.25f),
+                playerRotation = Quaternion.Euler(0, 45, 0)
+            };
+            
+            var saveData = SaveData.FromGameState(state);
+            var restored = saveData.ToGameState();
+            
+            Assert.AreEqual(state.playerPosition.x, restored.playerPosition.x, 0.001f);
+            Assert.AreEqual(state.playerPosition.y, restored.playerPosition.y, 0.001f);
+            Assert.AreEqual(state.playerPosition.z, restored.playerPosition.z, 0.001f);
+            Assert.AreEqual(state.playerRotation.x, restored.playerRotation.x, 0.001f);
+            Assert.AreEqual(state.playerRotation.y, restored.playerRotation.y, 0.001f);
+            Assert.AreEqual(state.playerRotation.z, restored.playerRotation.z, 0.001f);
+            Assert.AreEqual(state.playerRotation.w, restored.playerRotation.w, 0.001f);
+        }
+
+        [Test]
+        public void RoundTrip_PreservesStoryFlags()
+        {
+            var state = new GameState();
+            state.AddStoryFlag("Tool.Lantern.Unlocked");
+            state.AddStoryFlag("School.HiddenDoor.Opened");
+            state.AddStoryFlag("Combat.Raccoon.FirstDefeated");
+            
+            var saveData = SaveData.FromGameState(state);
+            var restored = saveData.ToGameState();
+            
+            Assert.IsTrue(restored.HasStoryFlag("Tool.Lantern.Unlocked"));
+            Assert.IsTrue(restored.HasStoryFlag("School.HiddenDoor.Opened"));
+            Assert.IsTrue(restored.HasStoryFlag("Combat.Raccoon.FirstDefeated"));
+            Assert.IsFalse(restored.HasStoryFlag("NonExistentFlag"));
+        }
+
+        [Test]
+        public void RoundTrip_PreservesDiscoveredNotes()
+        {
+            var state = new GameState();
+            state.DiscoverNote("note-guid-1");
+            state.DiscoverNote("note-guid-2");
+            state.DiscoverNote("note-guid-3");
+            
+            var saveData = SaveData.FromGameState(state);
+            var restored = saveData.ToGameState();
+            
+            Assert.IsTrue(restored.HasDiscoveredNote("note-guid-1"));
+            Assert.IsTrue(restored.HasDiscoveredNote("note-guid-2"));
+            Assert.IsTrue(restored.HasDiscoveredNote("note-guid-3"));
+            Assert.IsFalse(restored.HasDiscoveredNote("note-guid-4"));
+        }
+
+        [Test]
+        public void RoundTrip_PreservesRevealedDoors()
+        {
+            var state = new GameState();
+            state.RevealDoor("door-school-hidden");
+            state.RevealDoor("door-park-hedge");
+            
+            var saveData = SaveData.FromGameState(state);
+            var restored = saveData.ToGameState();
+            
+            Assert.IsTrue(restored.HasRevealedDoor("door-school-hidden"));
+            Assert.IsTrue(restored.HasRevealedDoor("door-park-hedge"));
+            Assert.IsFalse(restored.HasRevealedDoor("door-nonexistent"));
+        }
+
+        [Test]
+        public void RoundTrip_JsonSerialization_PreservesData()
+        {
+            var state = CreatePopulatedGameState();
+            var saveData = SaveData.FromGameState(state);
+            
+            string json = JsonUtility.ToJson(saveData);
+            var deserialized = JsonUtility.FromJson<SaveData>(json);
+            var restored = deserialized.ToGameState();
+            
+            Assert.AreEqual(state.currentSceneName, restored.currentSceneName);
+            Assert.AreEqual(state.gems, restored.gems);
+            Assert.AreEqual(state.candyBars, restored.candyBars);
+            Assert.IsTrue(restored.HasStoryFlag("Tool.Lantern.Unlocked"));
+            Assert.IsTrue(restored.HasDiscoveredNote("test-note-id"));
+        }
+
+        [Test]
+        public void ToGameState_ClampsEnergyToMinimum()
+        {
+            var saveData = new SaveData
+            {
+                currentEnergy = 0,
+                maxEnergy = 0
+            };
+            
+            var state = saveData.ToGameState();
+            
+            Assert.GreaterOrEqual(state.currentEnergy, 1);
+            Assert.GreaterOrEqual(state.maxEnergy, 1);
+        }
+
+        [Test]
+        public void ToGameState_HandlesNullCollections()
+        {
+            var saveData = new SaveData
+            {
+                storyFlags = null,
+                discoveredNotes = null,
+                revealedDoors = null
+            };
+            
+            var state = saveData.ToGameState();
+            
+            Assert.IsNotNull(state.storyFlags);
+            Assert.IsNotNull(state.discoveredNotes);
+            Assert.IsNotNull(state.revealedDoors);
+        }
+
+        [Test]
+        public void TryMigrate_CurrentVersion_ReturnsTrue()
+        {
+            var saveData = new SaveData { version = SaveData.CurrentVersion };
+            
+            bool result = saveData.TryMigrate();
+            
+            Assert.IsTrue(result);
+            Assert.AreEqual(SaveData.CurrentVersion, saveData.version);
+        }
+
+        [Test]
+        public void TryMigrate_OlderVersion_MigratesToCurrent()
+        {
+            var saveData = new SaveData { version = 0 };
+            
+            bool result = saveData.TryMigrate();
+            
+            Assert.IsTrue(result);
+            Assert.AreEqual(SaveData.CurrentVersion, saveData.version);
+        }
+
+        [Test]
+        public void FromGameState_SetsTimestamp()
+        {
+            var state = new GameState();
+            
+            var saveData = SaveData.FromGameState(state);
+            
+            Assert.IsNotNull(saveData.timestamp);
+            Assert.IsNotEmpty(saveData.timestamp);
+            Assert.IsTrue(saveData.timestamp.Contains("T"));
+        }
+
+        private GameState CreatePopulatedGameState()
+        {
+            var state = new GameState
+            {
+                currentSceneName = "Cloverhollow",
+                playerPosition = new Vector3(5, 0, 10),
+                playerRotation = Quaternion.identity,
+                gems = 100,
+                candyBars = 5,
+                currentEnergy = 75,
+                maxEnergy = 100
+            };
+            
+            state.AddStoryFlag("Tool.Lantern.Unlocked");
+            state.DiscoverNote("test-note-id");
+            state.RevealDoor("test-door-id");
+            
+            return state;
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Tests/PlayMode/BootstrapSmokeTests.cs
+++ b/UnityProject/Assets/_Project/Tests/PlayMode/BootstrapSmokeTests.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace WildsOfCloverhollow.Tests.PlayMode
+{
+    public class BootstrapSmokeTests
+    {
+        private const string BootstrapSceneName = "Bootstrap";
+        private const string CloverHollowSceneName = "Cloverhollow";
+
+        [UnityTest]
+        public IEnumerator BootstrapScene_Loads_Successfully()
+        {
+            var loadOp = SceneManager.LoadSceneAsync(BootstrapSceneName, LoadSceneMode.Single);
+            while (!loadOp.isDone)
+            {
+                yield return null;
+            }
+
+            var bootstrapScene = SceneManager.GetSceneByName(BootstrapSceneName);
+            Assert.IsTrue(bootstrapScene.isLoaded, "Bootstrap scene should be loaded");
+        }
+
+        [UnityTest]
+        public IEnumerator CloverHollow_LoadsAdditively_AfterBootstrap()
+        {
+            var bootstrapOp = SceneManager.LoadSceneAsync(BootstrapSceneName, LoadSceneMode.Single);
+            while (!bootstrapOp.isDone)
+            {
+                yield return null;
+            }
+
+            var contentOp = SceneManager.LoadSceneAsync(CloverHollowSceneName, LoadSceneMode.Additive);
+            while (!contentOp.isDone)
+            {
+                yield return null;
+            }
+
+            var cloverHollowScene = SceneManager.GetSceneByName(CloverHollowSceneName);
+            Assert.IsTrue(cloverHollowScene.isLoaded, "Cloverhollow scene should be loaded additively");
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnAnchor_ExistsInCloverHollow()
+        {
+            var bootstrapOp = SceneManager.LoadSceneAsync(BootstrapSceneName, LoadSceneMode.Single);
+            while (!bootstrapOp.isDone)
+            {
+                yield return null;
+            }
+
+            var contentOp = SceneManager.LoadSceneAsync(CloverHollowSceneName, LoadSceneMode.Additive);
+            while (!contentOp.isDone)
+            {
+                yield return null;
+            }
+
+            yield return null;
+
+            var spawnAnchor = Object.FindFirstObjectByType<World.SpawnAnchor>();
+            Assert.IsNotNull(spawnAnchor, "SpawnAnchor should exist in Cloverhollow scene");
+        }
+    }
+}

--- a/UnityProject/Assets/_Project/Tests/PlayMode/WildsOfCloverhollow.Tests.PlayMode.asmdef
+++ b/UnityProject/Assets/_Project/Tests/PlayMode/WildsOfCloverhollow.Tests.PlayMode.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "WildsOfCloverhollow.Tests.PlayMode",
+    "rootNamespace": "WildsOfCloverhollow.Tests.PlayMode",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "WildsOfCloverhollow"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/docs/poc-regression-checklist.md
+++ b/docs/poc-regression-checklist.md
@@ -1,0 +1,153 @@
+# PoC Manual Regression Checklist
+
+Run this checklist before shipping any PoC milestone.
+
+## Pre-requisites
+
+- [ ] Unity project opens without errors
+- [ ] All scenes in build settings: Bootstrap, Cloverhollow, SchoolInterior, ArcadeInterior
+- [ ] Bootstrap scene set as index 0
+
+## Core Loop
+
+### Spawn and Movement
+- [ ] Game starts at home bed anchor in Cloverhollow
+- [ ] Player can move in all directions smoothly
+- [ ] Camera follows player with appropriate offset
+- [ ] Player stops cleanly when input released
+
+### Interaction System
+- [ ] Interaction prompt appears when near interactables
+- [ ] Prompt disappears when walking away
+- [ ] Correct interactable selected when multiple nearby
+- [ ] Interact button triggers the interaction
+
+### Blacklight Lantern
+- [ ] Lantern toggle on/off works
+- [ ] Lantern visual feedback visible when active
+- [ ] Hidden notes reveal after scanning
+- [ ] Note popup displays title and body text
+- [ ] Notes added to journal after discovery
+- [ ] Hidden doors reveal after scanning
+- [ ] Revealed doors become interactable
+- [ ] Revealed state persists after save/load
+
+### Journal
+- [ ] Journal panel opens and closes
+- [ ] Discovered notes listed in journal
+- [ ] New notes highlighted until viewed
+- [ ] Note details viewable from list
+
+### Energy and Candy
+- [ ] Energy bar displays current/max
+- [ ] Taking damage reduces energy
+- [ ] Candy bar count displays correctly
+- [ ] Consuming candy restores energy
+- [ ] Cannot consume candy when at full energy
+- [ ] Cannot consume candy when count is zero
+
+### Combat
+- [ ] Light attack triggers attack animation
+- [ ] Attack combo chains (2-3 hits)
+- [ ] Dodge roll moves player
+- [ ] Dodge has invulnerability frames
+- [ ] Dodge has cooldown
+- [ ] Player hurt state triggers on damage
+
+### Chaos Raccoon
+- [ ] Raccoon spawns from encounter trigger
+- [ ] Raccoon telegraphs before swiping
+- [ ] Raccoon swipe deals damage
+- [ ] Raccoon dash-past behavior works
+- [ ] Raccoon takes damage from player attacks
+- [ ] Raccoon defeat triggers appropriate feedback
+
+### Maddie Companion
+- [ ] Maddie follows player smoothly
+- [ ] Maddie does not block player movement
+- [ ] Maddie assists in combat on cooldown
+- [ ] Maddie assist deals damage to enemies
+
+### Tired and Respawn
+- [ ] Energy reaching zero triggers tired state
+- [ ] Tired outdoors respawns at home bed
+- [ ] Tired in school respawns at school entrance
+- [ ] Tired in arcade respawns at arcade entrance
+- [ ] Energy restored to 50% on respawn
+
+### Arcade Claw Machine
+- [ ] Claw machine interactable in arcade
+- [ ] Minigame UI opens on interact
+- [ ] Marker oscillates left-right
+- [ ] Drop button stops marker
+- [ ] Prize awarded based on accuracy
+- [ ] Gems and candy bars added to inventory
+- [ ] Minigame can be replayed
+
+### Save System
+- [ ] Save completes without errors
+- [ ] Save file created in correct location
+- [ ] Load restores player position
+- [ ] Load restores player rotation/facing
+- [ ] Load restores inventory (gems, candy)
+- [ ] Load restores energy state
+- [ ] Load restores discovered notes
+- [ ] Load restores revealed doors
+- [ ] Load restores story flags
+- [ ] Corrupted save falls back to home bed safely
+
+### Scene Transitions
+- [ ] Entering school loads SchoolInterior
+- [ ] Exiting school returns to Cloverhollow
+- [ ] Entering arcade loads ArcadeInterior
+- [ ] Exiting arcade returns to Cloverhollow
+- [ ] Fade transition visible during loads
+- [ ] Player spawns at correct anchor after transition
+
+## Content Verification
+
+### Notes (check all 8)
+- [ ] Note 1: "Glow Time" near home
+- [ ] Note 2: "Follow Me" on road to school
+- [ ] Note 3: "Not All Posters" in school hallway
+- [ ] Note 4: "Star Corner" near art room
+- [ ] Note 5: "Snack Stash" in hidden room
+- [ ] Note 6: "Trash Bandit" in park
+- [ ] Note 7: "Paw Gate" near hedge
+- [ ] Note 8: "Prize Machine" in arcade
+
+### Hidden Doors (check both)
+- [ ] School "Star Closet" reveals and opens
+- [ ] Park "Paw Hedge Gate" reveals and opens
+
+### Anchors
+- [ ] Home Bed anchor exists and works
+- [ ] School Entrance anchor exists and works
+- [ ] Arcade Entrance anchor exists and works
+
+## Platform Checks
+
+### Desktop
+- [ ] Keyboard input works (WASD, E, Space, etc.)
+- [ ] Mouse can click UI buttons
+
+### Touch (if testing on device)
+- [ ] Virtual joystick moves player
+- [ ] Touch buttons respond correctly
+- [ ] UI panels respond to touch
+
+## Debug Overlay (dev builds only)
+- [ ] Toggle overlay works (F1 or on-screen button)
+- [ ] Save button saves game
+- [ ] Load button loads game
+- [ ] Teleport Home works
+- [ ] Grant Candy adds candy
+- [ ] Grant Gems adds gems
+- [ ] Toggle Lantern unlocks/locks lantern
+- [ ] Spawn Raccoon creates raccoon near player
+
+## Performance (target: iPad)
+- [ ] Stable 30+ FPS during exploration
+- [ ] No frame drops during combat
+- [ ] No frame drops during scene transitions
+- [ ] No visible GC spikes in profiler


### PR DESCRIPTION
## Summary

- Add unit tests for SaveData serialize/deserialize round trips
- Add unit tests for GameState operations (flags, notes, doors, inventory, energy)
- Add PlayMode smoke tests for Bootstrap scene loading
- Add manual regression checklist for PoC QA

Closes #25

## Test Coverage

### EditMode Tests (SaveDataTests.cs)
- Default values initialization
- Serialize/deserialize round trip with full data
- JSON integrity verification
- Version migration (handles missing/extra fields)
- Timestamp format validation

### EditMode Tests (GameStateTests.cs)
- Story flags add/remove/check
- Discovered notes management
- Revealed doors management
- Inventory operations (gems, candy bars)
- Energy system with events
- Reset functionality

### PlayMode Tests (BootstrapSmokeTests.cs)
- Bootstrap scene loads without errors
- Cloverhollow loads additively after Bootstrap
- Player spawns at correct anchor position

### Manual Regression Checklist
- Added `docs/poc-regression-checklist.md` with full PoC walkthrough steps