### PR TITLE
Add Journal UI to display discovered notes

### DIFF
--- a/GodotProject/scenes/ui/Journal.tscn
+++ b/GodotProject/scenes/ui/Journal.tscn
@@ -1,0 +1,72 @@
+[gd_scene load_steps=2 format=3 uid="uid://journal_ui"]
+
+[ext_resource type="Script" path="res://scripts/ui/Journal.gd" id="1_journal"]
+
+[node name="Journal" type="Control"]
+process_mode = 2
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_journal")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -250.0
+offset_top = -200.0
+offset_right = 250.0
+offset_bottom = 200.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = -10.0
+offset_bottom = -10.0
+
+[node name="Header" type="Label" parent="Panel/VBox"]
+layout_mode = 2
+text = "📓 Journal"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="Panel/VBox"]
+layout_mode = 2
+
+[node name="EmptyLabel" type="Label" parent="Panel/VBox"]
+layout_mode = 2
+text = "No notes discovered yet.
+Use the Lantern (Q) to find hidden messages!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NoteList" type="ItemList" parent="Panel/VBox"]
+visible = false
+custom_minimum_size = Vector2(0, 120)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="DetailPanel" type="VBoxContainer" parent="Panel/VBox"]
+visible = false
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="Panel/VBox/DetailPanel"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+
+[node name="Body" type="RichTextLabel" parent="Panel/VBox/DetailPanel"]
+layout_mode = 2
+size_flags_vertical = 3
+text = ""
+
+[node name="CloseButton" type="Button" parent="Panel/VBox"]
+layout_mode = 2
+text = "Close (J)"

--- a/GodotProject/scripts/bootstrap/Main.gd
+++ b/GodotProject/scripts/bootstrap/Main.gd
@@ -6,6 +6,10 @@ extends Node
 var _sticker_book: Control = null
 const STICKER_BOOK_SCENE := preload("res://scenes/ui/StickerBook.tscn")
 
+## Journal UI (lazy loaded)
+var _journal: Control = null
+const JOURNAL_SCENE := preload("res://scenes/ui/Journal.tscn")
+
 ## Starter stickers granted on new game
 const STARTER_STICKERS := ["bonk", "glitter_bandage", "pocket_sand"]
 
@@ -45,8 +49,12 @@ func _setup_new_game_if_needed() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	# Press J to open Sticker Book / Journal
+	# J key opens Journal
 	if event.is_action_pressed("journal"):
+		_toggle_journal()
+	
+	# I key opens Sticker Book
+	if event.is_action_pressed("open_sticker_book"):
 		_toggle_sticker_book()
 	
 	# Debug: Press B to start a test battle
@@ -54,8 +62,29 @@ func _input(event: InputEvent) -> void:
 		_debug_start_battle()
 
 
+## Toggle Journal UI
+func _toggle_journal() -> void:
+	# Close sticker book if open
+	if _sticker_book and _sticker_book.visible:
+		_sticker_book.hide()
+	
+	if _journal and _journal.visible:
+		_journal.toggle()
+		return
+	
+	if not _journal:
+		_journal = JOURNAL_SCENE.instantiate()
+		add_child(_journal)
+	
+	_journal.toggle()
+
+
 ## Toggle Sticker Book UI
 func _toggle_sticker_book() -> void:
+	# Close journal if open
+	if _journal and _journal.visible:
+		_journal.toggle()
+	
 	if _sticker_book and _sticker_book.visible:
 		_sticker_book.hide()
 		return

--- a/GodotProject/scripts/ui/Journal.gd
+++ b/GodotProject/scripts/ui/Journal.gd
@@ -1,0 +1,106 @@
+extends Control
+## Journal - UI panel showing discovered notes from Blacklight Lantern scanning.
+
+@onready var note_list: ItemList = $Panel/VBox/NoteList
+@onready var note_title: Label = $Panel/VBox/DetailPanel/Title
+@onready var note_body: RichTextLabel = $Panel/VBox/DetailPanel/Body
+@onready var empty_label: Label = $Panel/VBox/EmptyLabel
+
+var _game_state: Node
+var _discovered_notes: Array = []  # Array of loaded NoteDef resources
+
+
+func _ready() -> void:
+	_game_state = get_node_or_null("/root/GameState")
+	visible = false
+	_setup_ui()
+
+
+func _setup_ui() -> void:
+	if note_list:
+		note_list.item_selected.connect(_on_note_selected)
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("journal"):
+		toggle()
+
+
+func toggle() -> void:
+	visible = not visible
+	if visible:
+		refresh()
+		# Pause game while journal is open
+		get_tree().paused = true
+	else:
+		get_tree().paused = false
+
+
+func refresh() -> void:
+	_load_discovered_notes()
+	_populate_list()
+	_update_empty_state()
+	_clear_detail()
+
+
+func _load_discovered_notes() -> void:
+	_discovered_notes.clear()
+	
+	if not _game_state:
+		return
+	
+	var note_ids: Array = _game_state.discovered_notes
+	for note_id in note_ids:
+		var note_def := _load_note_def(note_id)
+		if note_def:
+			_discovered_notes.append(note_def)
+
+
+func _load_note_def(note_id: String) -> Resource:
+	# Try loading from data/notes/ directory
+	var path := "res://data/notes/%s.tres" % note_id
+	if ResourceLoader.exists(path):
+		return load(path)
+	return null
+
+
+func _populate_list() -> void:
+	if not note_list:
+		return
+	
+	note_list.clear()
+	for note_def in _discovered_notes:
+		var title: String = note_def.get("title") if note_def.get("title") else "Unknown Note"
+		note_list.add_item(title)
+
+
+func _update_empty_state() -> void:
+	var has_notes := _discovered_notes.size() > 0
+	
+	if note_list:
+		note_list.visible = has_notes
+	if empty_label:
+		empty_label.visible = not has_notes
+	if has_node("Panel/VBox/DetailPanel"):
+		get_node("Panel/VBox/DetailPanel").visible = has_notes
+
+
+func _clear_detail() -> void:
+	if note_title:
+		note_title.text = ""
+	if note_body:
+		note_body.text = ""
+
+
+func _on_note_selected(index: int) -> void:
+	if index < 0 or index >= _discovered_notes.size():
+		return
+	
+	var note_def: Resource = _discovered_notes[index]
+	var title: String = note_def.get("title") if note_def.get("title") else ""
+	var body: String = note_def.get("body") if note_def.get("body") else ""
+	
+	if note_title:
+		note_title.text = title
+	if note_body:
+		note_body.text = body


### PR DESCRIPTION
## Summary

- Add Journal.gd and Journal.tscn UI panel for viewing discovered notes
- J key toggles Journal (separate from Sticker Book on I key)
- Loads discovered note IDs from GameState and displays NoteDef content
- Empty state when no notes found yet
- Pauses game while Journal is open

Closes #58