### PR TITLE
Add arcade claw machine mini-game

### DIFF
--- a/GodotProject/data/tables/claw_machine_prizes.tres
+++ b/GodotProject/data/tables/claw_machine_prizes.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="PrizeTable" load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/PrizeTable.gd" id="1"]
+[ext_resource type="Resource" path="res://data/tables/claw_prize_gems_5.tres" id="2"]
+[ext_resource type="Resource" path="res://data/tables/claw_prize_gems_10.tres" id="3"]
+[ext_resource type="Resource" path="res://data/tables/claw_prize_candy.tres" id="4"]
+[ext_resource type="Resource" path="res://data/tables/claw_prize_gems_25.tres" id="5"]
+
+[resource]
+script = ExtResource("1")
+entries = [ExtResource("2"), ExtResource("3"), ExtResource("4"), ExtResource("5")]

--- a/GodotProject/data/tables/claw_prize_candy.tres
+++ b/GodotProject/data/tables/claw_prize_candy.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="PrizeTableEntry" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/PrizeTableEntry.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prize_type = "candy"
+prize_id = "candy_bar"
+amount = 1
+weight = 30

--- a/GodotProject/data/tables/claw_prize_gems_10.tres
+++ b/GodotProject/data/tables/claw_prize_gems_10.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="PrizeTableEntry" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/PrizeTableEntry.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prize_type = "gems"
+prize_id = ""
+amount = 10
+weight = 20

--- a/GodotProject/data/tables/claw_prize_gems_25.tres
+++ b/GodotProject/data/tables/claw_prize_gems_25.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="PrizeTableEntry" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/PrizeTableEntry.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prize_type = "gems"
+prize_id = ""
+amount = 25
+weight = 10

--- a/GodotProject/data/tables/claw_prize_gems_5.tres
+++ b/GodotProject/data/tables/claw_prize_gems_5.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="PrizeTableEntry" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/PrizeTableEntry.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prize_type = "gems"
+prize_id = ""
+amount = 5
+weight = 40

--- a/GodotProject/scenes/arcade/ClawMachineGame.tscn
+++ b/GodotProject/scenes/arcade/ClawMachineGame.tscn
@@ -1,0 +1,115 @@
+[gd_scene load_steps=2 format=3 uid="uid://claw_machine_game"]
+
+[ext_resource type="Script" path="res://scripts/arcade/ClawMachineGame.gd" id="1_claw"]
+
+[node name="ClawMachineGame" type="Control"]
+process_mode = 2
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_claw")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.1, 0.1, 0.15, 0.95)
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -150.0
+offset_right = 200.0
+offset_bottom = 150.0
+
+[node name="Title" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -100.0
+offset_top = 10.0
+offset_right = 100.0
+offset_bottom = 35.0
+text = "🎮 CLAW MACHINE 🎮"
+horizontal_alignment = 1
+
+[node name="GameArea" type="Control" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 40.0
+offset_bottom = -60.0
+
+[node name="MachineBackground" type="ColorRect" parent="Panel/GameArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_right = -20.0
+color = Color(0.2, 0.25, 0.3, 1.0)
+
+[node name="Prizes" type="Label" parent="Panel/GameArea"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -100.0
+offset_top = -40.0
+offset_right = 100.0
+text = "🧸 🍬 💎 🎁 🍭"
+horizontal_alignment = 1
+
+[node name="Claw" type="Control" parent="Panel/GameArea"]
+layout_mode = 0
+offset_left = 200.0
+offset_top = 30.0
+offset_right = 200.0
+offset_bottom = 30.0
+
+[node name="ClawSprite" type="Label" parent="Panel/GameArea/Claw"]
+layout_mode = 0
+offset_left = -15.0
+offset_right = 15.0
+offset_bottom = 30.0
+text = "🦀"
+horizontal_alignment = 1
+
+[node name="Instructions" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -150.0
+offset_top = -50.0
+offset_right = 150.0
+offset_bottom = -30.0
+text = "← → to move, SPACE to drop!"
+horizontal_alignment = 1
+
+[node name="PrizeLabel" type="Label" parent="Panel"]
+visible = false
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -150.0
+offset_top = -25.0
+offset_right = 150.0
+offset_bottom = -5.0
+horizontal_alignment = 1

--- a/GodotProject/scenes/world/World.tscn
+++ b/GodotProject/scenes/world/World.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://world_scene"]
+[gd_scene load_steps=17 format=3 uid="uid://world_scene"]
 
 [ext_resource type="Script" path="res://scripts/overworld/Player.gd" id="1_player"]
 [ext_resource type="Script" path="res://scripts/overworld/FollowCamera.gd" id="2_camera"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://scripts/overworld/LanternScanner.gd" id="4_lantern"]
 [ext_resource type="Script" path="res://scripts/overworld/HiddenNote.gd" id="5_hidden_note"]
 [ext_resource type="Resource" path="res://data/notes/park_bench_note.tres" id="6_note_def"]
+[ext_resource type="Script" path="res://scripts/arcade/ClawMachine.gd" id="7_claw"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_ground"]
 size = Vector3(20, 0.2, 20)
@@ -33,6 +34,12 @@ size = Vector3(0.3, 0.4, 0.05)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_note"]
 size = Vector3(0.5, 0.5, 0.5)
+
+[sub_resource type="BoxMesh" id="BoxMesh_claw"]
+size = Vector3(1.0, 1.5, 0.8)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_claw"]
+size = Vector3(1.5, 1.5, 1.5)
 
 [node name="World" type="Node3D"]
 
@@ -96,3 +103,15 @@ mesh = SubResource("BoxMesh_note")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="HiddenNote_ParkBench"]
 shape = SubResource("BoxShape3D_note")
+
+[node name="ClawMachine" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5, 0.75, -3)
+collision_layer = 8
+collision_mask = 2
+script = ExtResource("7_claw")
+
+[node name="Mesh" type="MeshInstance3D" parent="ClawMachine"]
+mesh = SubResource("BoxMesh_claw")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ClawMachine"]
+shape = SubResource("BoxShape3D_claw")

--- a/GodotProject/scripts/arcade/ClawMachine.gd
+++ b/GodotProject/scripts/arcade/ClawMachine.gd
@@ -1,0 +1,63 @@
+extends Area3D
+## ClawMachine - Interactable object that launches the claw machine mini-game.
+
+@export var prize_table_path: String = "res://data/tables/claw_machine_prizes.tres"
+
+const CLAW_GAME_SCENE := preload("res://scenes/arcade/ClawMachineGame.tscn")
+
+var _player_in_range: bool = false
+var _prize_table: Resource
+
+
+func _ready() -> void:
+	collision_layer = 8  # Layer 4 = interactables
+	collision_mask = 2   # Layer 2 = player
+	
+	body_entered.connect(_on_body_entered)
+	body_exited.connect(_on_body_exited)
+	
+	# Load prize table
+	if ResourceLoader.exists(prize_table_path):
+		_prize_table = load(prize_table_path)
+
+
+func _input(event: InputEvent) -> void:
+	if not _player_in_range:
+		return
+	
+	if event.is_action_pressed("interact"):
+		start_game()
+
+
+func _on_body_entered(body: Node3D) -> void:
+	if body.is_in_group("player"):
+		_player_in_range = true
+		print("[ClawMachine] Player in range. Press E to play!")
+
+
+func _on_body_exited(body: Node3D) -> void:
+	if body.is_in_group("player"):
+		_player_in_range = false
+
+
+func start_game() -> void:
+	print("[ClawMachine] Starting claw machine game!")
+	
+	var game_ui := CLAW_GAME_SCENE.instantiate()
+	game_ui.prize_table = _prize_table
+	
+	# Add to scene tree root for UI overlay
+	get_tree().root.add_child(game_ui)
+	
+	# Pause game tree while playing mini-game
+	get_tree().paused = true
+	
+	game_ui.game_finished.connect(_on_game_finished.bind(game_ui))
+
+
+func _on_game_finished(_prize: Resource, game_ui: Control) -> void:
+	# Game will free itself, just unpause
+	await get_tree().create_timer(0.1).timeout
+	if is_instance_valid(game_ui):
+		game_ui.queue_free()
+	get_tree().paused = false

--- a/GodotProject/scripts/arcade/ClawMachineGame.gd
+++ b/GodotProject/scripts/arcade/ClawMachineGame.gd
@@ -1,0 +1,137 @@
+extends Control
+## ClawMachineGame - Mini-game UI for the arcade claw machine.
+## Player moves claw left/right and drops to grab prizes.
+
+signal game_finished(prize: Resource)
+
+@export var prize_table: Resource  # PrizeTable
+
+@onready var claw_sprite: Control = $GameArea/Claw
+@onready var prize_label: Label = $PrizeLabel
+@onready var instruction_label: Label = $Instructions
+
+const CLAW_SPEED := 200.0
+const CLAW_MIN_X := 50.0
+const CLAW_MAX_X := 350.0
+const DROP_DURATION := 0.8
+const GRAB_DURATION := 0.5
+
+var _claw_x: float = 200.0
+var _is_dropping: bool = false
+var _game_active: bool = true
+var _game_state: Node
+
+
+func _ready() -> void:
+	_game_state = get_node_or_null("/root/GameState")
+	_claw_x = (CLAW_MIN_X + CLAW_MAX_X) / 2.0
+	_update_claw_position()
+	prize_label.visible = false
+	instruction_label.text = "← → to move, SPACE to drop!"
+
+
+func _process(delta: float) -> void:
+	if not _game_active or _is_dropping:
+		return
+	
+	# Move claw with arrow keys
+	if Input.is_action_pressed("move_left") or Input.is_key_pressed(KEY_LEFT):
+		_claw_x -= CLAW_SPEED * delta
+	if Input.is_action_pressed("move_right") or Input.is_key_pressed(KEY_RIGHT):
+		_claw_x += CLAW_SPEED * delta
+	
+	_claw_x = clamp(_claw_x, CLAW_MIN_X, CLAW_MAX_X)
+	_update_claw_position()
+
+
+func _input(event: InputEvent) -> void:
+	if not _game_active:
+		# Any key to close after prize shown
+		if event is InputEventKey and event.pressed:
+			_close_game()
+		return
+	
+	if _is_dropping:
+		return
+	
+	# Space or interact to drop
+	if event.is_action_pressed("ui_accept") or event.is_action_pressed("interact"):
+		_drop_claw()
+
+
+func _update_claw_position() -> void:
+	if claw_sprite:
+		claw_sprite.position.x = _claw_x
+
+
+func _drop_claw() -> void:
+	_is_dropping = true
+	instruction_label.text = "Dropping..."
+	
+	# Animate drop
+	var tween := create_tween()
+	tween.tween_property(claw_sprite, "position:y", 150.0, DROP_DURATION)
+	tween.tween_callback(_grab_prize)
+	tween.tween_property(claw_sprite, "position:y", 30.0, GRAB_DURATION)
+	tween.tween_callback(_show_prize)
+
+
+func _grab_prize() -> void:
+	# Roll the prize table
+	pass  # Prize determined in _show_prize
+
+
+func _show_prize() -> void:
+	_game_active = false
+	_is_dropping = false
+	
+	var prize: Resource = null
+	if prize_table and prize_table.has_method("roll_prize"):
+		prize = prize_table.roll_prize()
+	
+	if prize:
+		var prize_type: String = prize.get("prize_type") if prize.get("prize_type") else "gems"
+		var amount: int = prize.get("amount") if prize.get("amount") else 1
+		var prize_id: String = prize.get("prize_id") if prize.get("prize_id") else ""
+		
+		# Grant the prize
+		_grant_prize(prize_type, amount, prize_id)
+		
+		# Show prize message
+		match prize_type:
+			"gems":
+				prize_label.text = "🎉 You got %d gems!" % amount
+			"candy":
+				prize_label.text = "🎉 You got a candy bar!"
+			"sticker":
+				prize_label.text = "🎉 You got a sticker: %s!" % prize_id
+			_:
+				prize_label.text = "🎉 You won!"
+	else:
+		prize_label.text = "The claw slipped! Try again?"
+	
+	prize_label.visible = true
+	instruction_label.text = "Press any key to continue..."
+	
+	game_finished.emit(prize)
+
+
+func _grant_prize(prize_type: String, amount: int, prize_id: String) -> void:
+	if not _game_state:
+		return
+	
+	match prize_type:
+		"gems":
+			_game_state.gems += amount
+			print("[ClawMachine] Granted %d gems. Total: %d" % [amount, _game_state.gems])
+		"candy":
+			# TODO: Add candy inventory when implemented
+			print("[ClawMachine] Granted candy: ", prize_id)
+		"sticker":
+			if prize_id != "" and prize_id not in _game_state.owned_stickers:
+				_game_state.add_sticker(prize_id)
+				print("[ClawMachine] Granted sticker: ", prize_id)
+
+
+func _close_game() -> void:
+	queue_free()

--- a/GodotProject/scripts/data/PrizeTable.gd
+++ b/GodotProject/scripts/data/PrizeTable.gd
@@ -1,0 +1,26 @@
+extends Resource
+class_name PrizeTable
+## Table of possible prizes with weighted random selection.
+
+@export var entries: Array[Resource] = []  # Array of PrizeTableEntry
+
+## Roll a random prize from the table
+func roll_prize() -> Resource:
+	if entries.is_empty():
+		return null
+	
+	var total_weight: int = 0
+	for entry in entries:
+		var w: int = entry.get("weight") if entry.get("weight") else 1
+		total_weight += w
+	
+	var roll: int = randi() % total_weight
+	var cumulative: int = 0
+	
+	for entry in entries:
+		var w: int = entry.get("weight") if entry.get("weight") else 1
+		cumulative += w
+		if roll < cumulative:
+			return entry
+	
+	return entries[0]

--- a/GodotProject/scripts/data/PrizeTableEntry.gd
+++ b/GodotProject/scripts/data/PrizeTableEntry.gd
@@ -1,0 +1,8 @@
+extends Resource
+class_name PrizeTableEntry
+## A single entry in a prize table with weight for random selection.
+
+@export var prize_type: String = "gems"  # "gems", "candy", "sticker"
+@export var prize_id: String = ""  # For stickers, the sticker ID
+@export var amount: int = 1  # For gems/candy, how many
+@export var weight: int = 10  # Higher = more common


### PR DESCRIPTION
## Summary

- Add ClawMachine interactable that launches mini-game when player presses E
- Implement ClawMachineGame UI with claw movement (← →) and drop (SPACE)
- Create PrizeTable and PrizeTableEntry Resources for weighted random prizes
- Prize pool: 5/10/25 gems, candy bars
- Place test claw machine in World at (-5, 0.75, -3)
- Game pauses while mini-game is active

Closes #60